### PR TITLE
feat: Add status bar with global panel counts and max limits

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -4,6 +4,10 @@ const DEFAULT_WEB_WIDTH = 750;
 const DEFAULT_TERM_WIDTH = 620;
 const DEFAULT_FILE_WIDTH = 900;
 
+const MAX_TERMINAL_PANELS = 20;
+const MAX_WEB_PANELS = 20;
+const MAX_FILE_PANELS = 10;
+
 let state = { activeGroupId: null, groups: [], templates: [] };
 
 // Map<panelId, { terminal, fitAddon, cleanup, termId }>
@@ -163,6 +167,11 @@ async function addPanel(type) {
   const group = getActiveGroup();
   if (!group) return;
 
+  const maxLimits = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
+  const maxForType = maxLimits[type];
+  const globalCount = state.groups.flatMap(g => g.panels).filter(p => p.type === type).length;
+  if (maxForType && globalCount >= maxForType) return;
+
   let extraProps = {};
   if (type === 'web') {
     extraProps = { url: '' };
@@ -192,6 +201,7 @@ async function addPanel(type) {
       const resizeHandle = createResizeHandle(panel.id);
       cached.insertBefore(panelEl, addControls);
       cached.insertBefore(resizeHandle, addControls);
+      renderStatusBar();
     } else {
       // Was showing empty state — rebuild entirely
       removeCachedGroup(state.activeGroupId);
@@ -231,6 +241,7 @@ function removePanel(panelId) {
       }
       panelEl.remove();
     }
+    renderStatusBar();
   } else {
     // Group is empty or no cache — rebuild
     removeCachedGroup(state.activeGroupId);

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -13,6 +13,7 @@
     <div id="sidebar"></div>
     <div id="main">
       <div id="panel-strip"></div>
+      <div id="status-bar"></div>
     </div>
   </div>
 
@@ -23,6 +24,7 @@
   <script src="workspace-modal.js"></script>
   <script src="sidebar.js"></script>
   <script src="panel-strip.js"></script>
+  <script src="status-bar.js"></script>
   <script src="web-panel.js"></script>
   <script src="term-panel.js"></script>
   <script src="file-panel.js"></script>

--- a/renderer/panel-strip.js
+++ b/renderer/panel-strip.js
@@ -16,6 +16,7 @@ function renderPanelStrip(scrollToEnd = true) {
     cached.hidden = false;
     touchLRU(group.id);
     requestAnimationFrame(() => fitVisibleTerminals(group.id));
+    renderStatusBar();
     return;
   }
 
@@ -90,6 +91,8 @@ function renderPanelStrip(scrollToEnd = true) {
   cacheContainer(group.id, wrapper);
   touchLRU(group.id);
   evictLRU();
+
+  renderStatusBar();
 
   // Scroll to the rightmost panel after adding
   requestAnimationFrame(() => {

--- a/renderer/status-bar.js
+++ b/renderer/status-bar.js
@@ -1,0 +1,22 @@
+// status-bar.js - Renders panel count status bar
+
+function renderStatusBar() {
+  const bar = document.getElementById('status-bar');
+  if (!bar) return;
+
+  const allPanels = state.groups.flatMap(g => g.panels);
+
+  const types = [
+    { type: 'terminal', label: 'Terminal', max: MAX_TERMINAL_PANELS },
+    { type: 'web', label: 'Web', max: MAX_WEB_PANELS },
+    { type: 'file', label: 'Files', max: MAX_FILE_PANELS },
+  ];
+
+  bar.innerHTML = types.map(({ type, label, max }) => {
+    const count = allPanels.filter(p => p.type === type).length;
+    return `<span class="status-bar-item">` +
+      `<span class="status-bar-dot ${type}"></span>` +
+      `${label} ${count} / ${max}` +
+      `</span>`;
+  }).join('');
+}

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -152,13 +152,46 @@ body {
 #panel-strip {
   display: flex;
   align-items: stretch;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   overflow-x: auto;
   overflow-y: hidden;
   padding: 12px 12px 12px 12px;
   gap: 0;
   position: relative;
 }
+
+/* ── Status bar ─────────────────────────────────── */
+
+#status-bar {
+  height: 26px;
+  min-height: 26px;
+  background: #16213e;
+  border-top: 1px solid #0f3460;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  gap: 18px;
+  font-size: 11px;
+  color: #889;
+}
+
+.status-bar-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.status-bar-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-bar-dot.terminal { background: #50fa7b; }
+.status-bar-dot.web { background: #8be9fd; }
+.status-bar-dot.file { background: #f1fa8c; }
 
 .group-container {
   display: flex;


### PR DESCRIPTION
Show panel counts across all workspaces (active + background) in a status bar at the bottom. Enforce global max limits per panel type (20 terminal, 20 web, 10 file).

Closes #9 