### PR TITLE
fix: Prevent "Object has been destroyed" error on macOS window close

### DIFF
--- a/main.js
+++ b/main.js
@@ -51,6 +51,13 @@ function createWindow() {
     },
   });
 
+  win.on('close', () => {
+    for (const [id, term] of terminals) {
+      try { term.kill(); } catch (e) {}
+    }
+    terminals.clear();
+  });
+
   win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
 }
 
@@ -96,12 +103,16 @@ ipcMain.handle('terminal:create', (event, { cols, rows, cwd, initialCommand }) =
   });
 
   term.onData((data) => {
-    event.sender.send(`terminal:data:${id}`, data);
+    if (!event.sender.isDestroyed()) {
+      event.sender.send(`terminal:data:${id}`, data);
+    }
   });
 
   term.onExit(() => {
     terminals.delete(id);
-    event.sender.send(`terminal:exit:${id}`);
+    if (!event.sender.isDestroyed()) {
+      event.sender.send(`terminal:exit:${id}`);
+    }
   });
 
   terminals.set(id, term);


### PR DESCRIPTION
Kill all PTY processes and clear terminals map on window close event, and add isDestroyed() guards on event.sender.send() calls to handle any residual PTY events after webContents destruction.