### PR TITLE
fix: Keep terminal PTY cols in sync with container width via ResizeOb…

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -69,6 +69,16 @@ async function init() {
 
   renderSidebar();
   renderPanelStrip();
+
+  let windowResizeTimer = null;
+  window.addEventListener('resize', () => {
+    clearTimeout(windowResizeTimer);
+    windowResizeTimer = setTimeout(() => {
+      if (state.activeGroupId) {
+        fitVisibleTerminals(state.activeGroupId);
+      }
+    }, 100);
+  });
 }
 
 function saveState() {

--- a/renderer/term-panel.js
+++ b/renderer/term-panel.js
@@ -44,6 +44,11 @@ async function mountTerminal(panel, container) {
   await new Promise(resolve => requestAnimationFrame(resolve));
   try { fitAddon.fit(); } catch (e) {}
 
+  const resizeObserver = new ResizeObserver(() => {
+    try { fitAddon.fit(); } catch (e) {}
+  });
+  resizeObserver.observe(container);
+
   // Spawn the pty process
   const { id: termId, error } = await window.electronAPI.createTerminal({
     cols: terminal.cols,
@@ -89,6 +94,7 @@ async function mountTerminal(panel, container) {
   });
 
   const cleanup = () => {
+    resizeObserver.disconnect();
     removeDataListener();
     try { terminal.dispose(); } catch (e) {}
     window.electronAPI.killTerminal(termId);


### PR DESCRIPTION
…server

Add ResizeObserver to terminal containers so fitAddon.fit() is called whenever the container dimensions change, preventing text truncation when tab-completing long filenames. Also add a debounced window resize handler as a safety net to re-fit all visible terminals.

Closes #19 