### PR TITLE
fix: Prevent terminal eviction on group switch and show active PTY co…

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -48,7 +48,7 @@ async function init() {
   const saved = await window.electronAPI.loadState();
   if (saved && Array.isArray(saved.groups) && saved.groups.length > 0) {
     state = saved;
-    if (!state.maxCachedGroups) state.maxCachedGroups = 5;
+    if (!state.maxCachedGroups || state.maxCachedGroups === 5) state.maxCachedGroups = 20;
     if (!state.templates) state.templates = [];
     if (!state.urlHistory) state.urlHistory = [];
     // Migrate: ensure all groups have lspServers
@@ -62,7 +62,7 @@ async function init() {
     const id = generateId();
     state = {
       activeGroupId: id,
-      maxCachedGroups: 5,
+      maxCachedGroups: 20,
       groups: [{ id, label: 'Work 1', panels: [], lspServers: [] }],
     };
   }

--- a/renderer/group-cache.js
+++ b/renderer/group-cache.js
@@ -4,7 +4,7 @@ const groupDOMCache = new Map(); // groupId -> wrapper div
 const lruOrder = [];             // index 0 = least recently used
 
 function getMaxCached() {
-  return (state && state.maxCachedGroups) || 5;
+  return (state && state.maxCachedGroups) || 20;
 }
 
 function touchLRU(groupId) {
@@ -15,6 +15,7 @@ function touchLRU(groupId) {
 
 function evictLRU() {
   const max = getMaxCached();
+  let evicted = false;
   while (lruOrder.length > max) {
     const evictId = lruOrder.shift();
     console.log(`[GroupCache] Evicting group=${evictId} (cached=${groupDOMCache.size} max=${max})`);
@@ -25,7 +26,9 @@ function evictLRU() {
     }
     const group = state.groups.find(g => g.id === evictId);
     if (group) killGroupTerminals(group);
+    evicted = true;
   }
+  if (evicted) renderStatusBar();
 }
 
 function getCachedContainer(groupId) {

--- a/renderer/status-bar.js
+++ b/renderer/status-bar.js
@@ -14,6 +14,13 @@ function renderStatusBar() {
 
   bar.innerHTML = types.map(({ type, label, max }) => {
     const count = allPanels.filter(p => p.type === type).length;
+    if (type === 'terminal') {
+      const activeCount = activeTerminals.size;
+      return `<span class="status-bar-item">` +
+        `<span class="status-bar-dot ${type}"></span>` +
+        `${label} ${activeCount} active · ${count} / ${max}` +
+        `</span>`;
+    }
     return `<span class="status-bar-item">` +
       `<span class="status-bar-dot ${type}"></span>` +
       `${label} ${count} / ${max}` +

--- a/renderer/term-panel.js
+++ b/renderer/term-panel.js
@@ -60,6 +60,7 @@ async function mountTerminal(panel, container) {
   if (error) {
     terminal.write(`\r\n\x1b[31mError: ${error}\x1b[0m\r\n`);
     activeTerminals.set(panel.id, { terminal, fitAddon, searchAddon, cleanup: () => terminal.dispose() });
+    renderStatusBar();
     return;
   }
 
@@ -71,6 +72,7 @@ async function mountTerminal(panel, container) {
   window.electronAPI.onTerminalExit(termId, () => {
     terminal.write('\r\n\x1b[2m[process exited]\x1b[0m\r\n');
     activeTerminals.delete(panel.id);
+    renderStatusBar();
   });
 
   // Shift+Enter: insert a newline without executing the command
@@ -102,4 +104,5 @@ async function mountTerminal(panel, container) {
   };
 
   activeTerminals.set(panel.id, { terminal, fitAddon, searchAddon, cleanup, termId });
+  renderStatusBar();
 }


### PR DESCRIPTION
…unt in status bar

Increase maxCachedGroups from 5 to 20 (matching MAX_TERMINAL_PANELS) so switching between groups no longer kills PTY processes. Update status bar to display active terminal count alongside total panels (e.g. "Terminal 5 active · 8 / 20") and keep it in sync on spawn, exit, and eviction events.