### PR TITLE
fix: Refresh button retries original URL after network error and URL …

### DIFF
--- a/renderer/web-panel.js
+++ b/renderer/web-panel.js
@@ -103,6 +103,8 @@ function renderWebPanel(panel, container) {
 
   console.log(`[WebPanel] Created webview panel=${panel.id} url=${panel.url || 'about:blank'} partition=persist:webpanels`);
 
+  let lastRealUrl = panel.url || '';
+
   const navigate = (raw) => {
     let url = raw.trim();
     if (!url) return;
@@ -113,6 +115,7 @@ function renderWebPanel(panel, container) {
         url = 'https://www.google.com/search?q=' + encodeURIComponent(url);
       }
     }
+    lastRealUrl = url;
     webview.src = url;
     urlInput.value = url;
     updatePanelUrl(panel.id, url);
@@ -121,7 +124,14 @@ function renderWebPanel(panel, container) {
 
   backBtn.addEventListener('click', () => webview.goBack());
   forwardBtn.addEventListener('click', () => webview.goForward());
-  refreshBtn.addEventListener('click', () => webview.reload());
+  refreshBtn.addEventListener('click', () => {
+    const currentUrl = webview.getURL();
+    if (currentUrl.startsWith('data:') && lastRealUrl) {
+      navigate(lastRealUrl);
+    } else {
+      webview.reload();
+    }
+  });
 
   urlInput.addEventListener('focus', () => {
     showDropdown(urlInput.value);
@@ -212,9 +222,12 @@ function renderWebPanel(panel, container) {
 
   webview.addEventListener('did-navigate', e => {
     console.log(`[WebPanel] did-navigate panel=${panel.id} url=${e.url}`);
-    urlInput.value = e.url;
-    updatePanelUrl(panel.id, e.url);
-    addToUrlHistory(e.url, '');
+    if (!e.url.startsWith('data:')) {
+      lastRealUrl = e.url;
+      urlInput.value = e.url;
+      updatePanelUrl(panel.id, e.url);
+      addToUrlHistory(e.url, '');
+    }
     if (window.electronAPI.debugGetCookieCount) {
       window.electronAPI.debugGetCookieCount().then(info => {
         console.log(`[WebPanel] Cookies after navigate: total=${info.total} session=${info.session} persistent=${info.persistent}`);
@@ -223,7 +236,8 @@ function renderWebPanel(panel, container) {
   });
 
   webview.addEventListener('did-navigate-in-page', e => {
-    if (e.isMainFrame) {
+    if (e.isMainFrame && !e.url.startsWith('data:')) {
+      lastRealUrl = e.url;
       urlInput.value = e.url;
       updatePanelUrl(panel.id, e.url);
       addToUrlHistory(e.url, '');
@@ -233,6 +247,7 @@ function renderWebPanel(panel, container) {
   webview.addEventListener('did-fail-load', e => {
     console.log(`[WebPanel] did-fail-load panel=${panel.id} error=${e.errorDescription} code=${e.errorCode} url=${e.validatedURL}`);
     if (e.errorCode === 0 || e.errorCode === -3) return; // ignore aborted loads
+    const retryUrl = e.validatedURL || lastRealUrl || '';
     const errorPage = `
       <html>
       <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; background: #1e1e2e; color: #cdd6f4;">
@@ -241,6 +256,7 @@ function renderWebPanel(panel, container) {
           <h2 style="margin: 0 0 0.5rem;">Failed to load page</h2>
           <p style="color: #a6adc8; margin: 0 0 1rem;">${e.validatedURL || ''}</p>
           <p style="color: #f38ba8;">${e.errorDescription || 'Unknown error'} (${e.errorCode})</p>
+          ${retryUrl ? `<button data-url="${encodeURIComponent(retryUrl)}" onclick="window.location.href=decodeURIComponent(this.dataset.url)" style="margin-top: 1rem; padding: 0.5rem 1.5rem; border: none; border-radius: 6px; background: #89b4fa; color: #1e1e2e; font-size: 1rem; cursor: pointer;">Retry</button>` : ''}
         </div>
       </body>
       </html>`;
@@ -271,6 +287,7 @@ function renderWebPanel(panel, container) {
   });
 
   webview.addEventListener('page-title-updated', e => {
+    if (webview.getURL().startsWith('data:')) return;
     // Update the panel header label with the page title
     const panelEl = webview.closest('.panel');
     if (panelEl) {


### PR DESCRIPTION
…bar no longer shows data URLs

When a page fails to load, the error page is loaded as a data: URL. Previously, clicking refresh would reload the data URL instead of retrying the original page, and the URL bar would display the raw data URL. This adds a lastRealUrl tracker so refresh retries the intended URL, guards navigation handlers from overwriting state with data URLs, adds a Retry button to the error page, and prevents error page titles from corrupting URL history.

Closes #29 