### PR TITLE
fix: Cmd+R refreshes only the focused web panel instead of reloading …

### DIFF
--- a/main.js
+++ b/main.js
@@ -472,6 +472,32 @@ app.whenReady().then(async () => {
     }
   });
 
+  // Custom application menu — omits Reload / Force Reload so Cmd+R
+  // doesn't blow away the renderer (the renderer handles it per-panel).
+  const appMenu = Menu.buildFromTemplate([
+    ...(process.platform === 'darwin' ? [{ label: app.name, submenu: [
+      { role: 'about' }, { type: 'separator' }, { role: 'services' },
+      { type: 'separator' }, { role: 'hide' }, { role: 'hideOthers' },
+      { role: 'unhide' }, { type: 'separator' }, { role: 'quit' },
+    ]}] : []),
+    { label: 'Edit', submenu: [
+      { role: 'undo' }, { role: 'redo' }, { type: 'separator' },
+      { role: 'cut' }, { role: 'copy' }, { role: 'paste' }, { role: 'selectAll' },
+    ]},
+    { label: 'View', submenu: [
+      { role: 'toggleDevTools' }, { type: 'separator' },
+      { role: 'resetZoom' }, { role: 'zoomIn' }, { role: 'zoomOut' },
+      { type: 'separator' }, { role: 'togglefullscreen' },
+    ]},
+    { label: 'Window', submenu: [
+      { role: 'minimize' }, { role: 'zoom' },
+      ...(process.platform === 'darwin'
+        ? [{ type: 'separator' }, { role: 'front' }]
+        : [{ role: 'close' }]),
+    ]},
+  ]);
+  Menu.setApplicationMenu(appMenu);
+
   debugLog('About to call createWindow()');
   createWindow();
   debugLog('createWindow() returned');

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -345,4 +345,21 @@ document.addEventListener('keydown', e => {
   }
 });
 
+// ── Global Cmd+R / Ctrl+R handler ────────────────
+document.addEventListener('keydown', e => {
+  if ((e.metaKey || e.ctrlKey) && e.key === 'r') {
+    e.preventDefault();
+    if (!focusedPanelId) return;
+    const group = getActiveGroup();
+    if (!group) return;
+    const panel = group.panels.find(p => p.id === focusedPanelId);
+    if (!panel || panel.type !== 'web') return;
+    const panelEl = document.querySelector(`[data-panel-id="${focusedPanelId}"]`);
+    if (panelEl) {
+      const refreshBtn = panelEl.querySelector('.nav-btn[title="Refresh"]');
+      if (refreshBtn) refreshBtn.click();
+    }
+  }
+});
+
 document.addEventListener('DOMContentLoaded', init);

--- a/renderer/web-panel.js
+++ b/renderer/web-panel.js
@@ -183,7 +183,7 @@ function renderWebPanel(panel, container) {
   });
 
   // Inject Cmd+F interceptor into webview guest page
-  const injectCmdFInterceptor = () => {
+  const injectKeyInterceptors = () => {
     webview.executeJavaScript(`
       if (!window.__panelSearchInjected) {
         window.__panelSearchInjected = true;
@@ -193,19 +193,27 @@ function renderWebPanel(panel, container) {
             e.stopPropagation();
             console.log('__PANEL_SEARCH_CMD_F__');
           }
+          if ((e.metaKey || e.ctrlKey) && e.key === 'r') {
+            e.preventDefault();
+            e.stopPropagation();
+            console.log('__PANEL_REFRESH_CMD_R__');
+          }
         }, true);
       }
     `).catch(() => {});
   };
 
-  webview.addEventListener('dom-ready', injectCmdFInterceptor);
-  webview.addEventListener('did-navigate', injectCmdFInterceptor);
+  webview.addEventListener('dom-ready', injectKeyInterceptors);
+  webview.addEventListener('did-navigate', injectKeyInterceptors);
 
-  // Handle Cmd+F from webview
+  // Handle Cmd+F and Cmd+R from webview
   webview.addEventListener('console-message', e => {
     if (e.message === '__PANEL_SEARCH_CMD_F__') {
       setFocusedPanel(panel.id);
       showPanelSearch(panel.id);
+    }
+    if (e.message === '__PANEL_REFRESH_CMD_R__') {
+      refreshBtn.click();
     }
   });
 


### PR DESCRIPTION
…the entire window

Set a custom application menu without Reload/Force Reload to prevent Electron's default menu from reloading the BrowserWindow. Add Cmd+R keydown handlers both in the renderer (for when outer UI has focus) and injected into webview guest pages (for when the webview has focus), routing the shortcut to the existing per-panel refresh button.

Closes #30 