### PR TITLE
feat: Add per-panel settings configuration via gear button

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -310,6 +310,91 @@ function updatePanelWidth(panelId, width) {
   if (panel) panel.width = Math.max(300, Math.round(width));
 }
 
+function applyPanelSettings(panelId, newSettings) {
+  const group = getActiveGroup();
+  if (!group) return;
+  const panel = group.panels.find(p => p.id === panelId);
+  if (!panel) return;
+
+  if (panel.type === 'terminal') {
+    const cwdChanged = (newSettings.cwd || '') !== (panel.cwd || '');
+    const cmdChanged = (newSettings.initialCommand || '') !== (panel.initialCommand || '');
+    panel.cwd = newSettings.cwd || '';
+    panel.initialCommand = newSettings.initialCommand || '';
+    if (cwdChanged || cmdChanged) {
+      rebuildTerminalPanel(panelId, panel);
+    }
+  } else if (panel.type === 'web') {
+    const urlChanged = (newSettings.url || '') !== (panel.url || '');
+    if (urlChanged && newSettings.url) {
+      navigateWebPanel(panelId, newSettings.url);
+    }
+  } else if (panel.type === 'file') {
+    const dirChanged = (newSettings.rootDir || '') !== (panel.rootDir || '');
+    panel.rootDir = newSettings.rootDir || '';
+    if (dirChanged) {
+      panel.openFile = null;
+      rebuildFilePanel(panelId, panel);
+    }
+  }
+
+  saveState();
+}
+
+function rebuildTerminalPanel(panelId, panel) {
+  // Kill existing PTY
+  if (activeTerminals.has(panelId)) {
+    const { cleanup } = activeTerminals.get(panelId);
+    if (cleanup) cleanup();
+  }
+
+  const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`);
+  if (!panelEl) return;
+  const content = panelEl.querySelector('.panel-content');
+  if (!content) return;
+  content.innerHTML = '';
+  renderTermPanel(panel, content);
+}
+
+function navigateWebPanel(panelId, url) {
+  let normalizedUrl = url.trim();
+  if (!normalizedUrl) return;
+  if (!/^[a-z][a-z\d+\-.]*:/i.test(normalizedUrl)) {
+    if (/^[\w-]+(\.[\w-]+)+/.test(normalizedUrl) && !normalizedUrl.includes(' ')) {
+      normalizedUrl = 'https://' + normalizedUrl;
+    } else {
+      normalizedUrl = 'https://www.google.com/search?q=' + encodeURIComponent(normalizedUrl);
+    }
+  }
+
+  const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`);
+  if (!panelEl) return;
+  const webview = panelEl.querySelector('webview');
+  if (webview) {
+    webview.src = normalizedUrl;
+  }
+  const urlInput = panelEl.querySelector('.url-input');
+  if (urlInput) {
+    urlInput.value = normalizedUrl;
+  }
+  // State is updated by the did-navigate handler on the webview
+}
+
+function rebuildFilePanel(panelId, panel) {
+  // Dispose active editor
+  if (activeEditors.has(panelId)) {
+    const { dispose } = activeEditors.get(panelId);
+    if (dispose) dispose();
+  }
+
+  const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`);
+  if (!panelEl) return;
+  const content = panelEl.querySelector('.panel-content');
+  if (!content) return;
+  content.innerHTML = '';
+  renderFilePanel(panel, content);
+}
+
 function addToUrlHistory(url, title) {
   if (!url || url === 'about:blank' || url.startsWith('data:')) return;
   state.urlHistory = state.urlHistory.filter(entry => entry.url !== url);

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -23,6 +23,7 @@
   <script src="app.js"></script>
   <script src="group-cache.js"></script>
   <script src="workspace-modal.js"></script>
+  <script src="panel-settings-modal.js"></script>
   <script src="sidebar.js"></script>
   <script src="panel-strip.js"></script>
   <script src="panel-search.js"></script>

--- a/renderer/panel-drag.js
+++ b/renderer/panel-drag.js
@@ -9,7 +9,7 @@ function initPanelDrag(panelEl) {
   if (!header) return;
 
   header.addEventListener('mousedown', e => {
-    if (e.target.closest('.panel-close-btn')) return;
+    if (e.target.closest('.panel-close-btn') || e.target.closest('.panel-settings-btn')) return;
     e.preventDefault();
     dragState = {
       panelEl,

--- a/renderer/panel-settings-modal.js
+++ b/renderer/panel-settings-modal.js
@@ -1,0 +1,140 @@
+// panel-settings-modal.js - Per-panel settings modal
+
+function createSettingsTextField(placeholder, value, onChange) {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'modal-input modal-field-input';
+  input.placeholder = placeholder;
+  input.value = value;
+  input.addEventListener('input', () => onChange(input.value));
+  return input;
+}
+
+function createSettingsFieldWithBrowse(placeholder, value, onChange) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'modal-browse-field';
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'modal-input modal-field-input';
+  input.placeholder = placeholder;
+  input.value = value;
+  input.addEventListener('input', () => onChange(input.value));
+
+  const browseBtn = document.createElement('button');
+  browseBtn.className = 'modal-btn modal-btn-browse';
+  browseBtn.textContent = '...';
+  browseBtn.title = 'Browse';
+  browseBtn.addEventListener('click', async () => {
+    const result = await window.electronAPI.openDirectory();
+    if (!result.cancelled) {
+      input.value = result.path;
+      onChange(result.path);
+    }
+  });
+
+  wrapper.appendChild(input);
+  wrapper.appendChild(browseBtn);
+  return wrapper;
+}
+
+function showPanelSettingsModal(panel) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+
+  const container = document.createElement('div');
+  container.className = 'modal-container';
+  container.style.width = '460px';
+
+  // Header
+  const header = document.createElement('div');
+  header.className = 'modal-header';
+  const typeNames = { terminal: 'Terminal', web: 'Web', file: 'File' };
+  header.textContent = (typeNames[panel.type] || 'Panel') + ' Settings';
+  container.appendChild(header);
+
+  // Track new settings
+  const newSettings = {};
+
+  // Type-specific fields
+  const fieldsSection = document.createElement('div');
+  fieldsSection.style.display = 'flex';
+  fieldsSection.style.flexDirection = 'column';
+  fieldsSection.style.gap = '10px';
+
+  if (panel.type === 'terminal') {
+    const cwdLabel = document.createElement('label');
+    cwdLabel.className = 'modal-label';
+    cwdLabel.textContent = 'Working Directory';
+    fieldsSection.appendChild(cwdLabel);
+
+    newSettings.cwd = panel.cwd || '';
+    const cwdField = createSettingsFieldWithBrowse('Directory', panel.cwd || '', val => {
+      newSettings.cwd = val;
+    });
+    fieldsSection.appendChild(cwdField);
+
+    const cmdLabel = document.createElement('label');
+    cmdLabel.className = 'modal-label';
+    cmdLabel.textContent = 'Startup Command';
+    fieldsSection.appendChild(cmdLabel);
+
+    newSettings.initialCommand = panel.initialCommand || '';
+    const cmdField = createSettingsTextField('Startup command', panel.initialCommand || '', val => {
+      newSettings.initialCommand = val;
+    });
+    fieldsSection.appendChild(cmdField);
+  } else if (panel.type === 'web') {
+    const urlLabel = document.createElement('label');
+    urlLabel.className = 'modal-label';
+    urlLabel.textContent = 'URL';
+    fieldsSection.appendChild(urlLabel);
+
+    newSettings.url = panel.url || '';
+    const urlField = createSettingsTextField('URL', panel.url || '', val => {
+      newSettings.url = val;
+    });
+    fieldsSection.appendChild(urlField);
+  } else if (panel.type === 'file') {
+    const dirLabel = document.createElement('label');
+    dirLabel.className = 'modal-label';
+    dirLabel.textContent = 'Root Directory';
+    fieldsSection.appendChild(dirLabel);
+
+    newSettings.rootDir = panel.rootDir || '';
+    const dirField = createSettingsFieldWithBrowse('Root directory', panel.rootDir || '', val => {
+      newSettings.rootDir = val;
+    });
+    fieldsSection.appendChild(dirField);
+  }
+
+  container.appendChild(fieldsSection);
+
+  // Footer
+  const footer = document.createElement('div');
+  footer.className = 'modal-footer';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'modal-btn modal-btn-cancel';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', () => overlay.remove());
+
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'modal-btn modal-btn-create';
+  saveBtn.textContent = 'Save';
+  saveBtn.addEventListener('click', () => {
+    applyPanelSettings(panel.id, newSettings);
+    overlay.remove();
+  });
+
+  footer.appendChild(cancelBtn);
+  footer.appendChild(saveBtn);
+  container.appendChild(footer);
+
+  overlay.appendChild(container);
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) overlay.remove();
+  });
+
+  document.body.appendChild(overlay);
+}

--- a/renderer/panel-strip.js
+++ b/renderer/panel-strip.js
@@ -127,12 +127,22 @@ function createPanelElement(panel) {
   typeLabel.className = 'panel-type-label';
   typeLabel.textContent = panel.type === 'web' ? 'Web' : panel.type === 'file' ? 'Files' : 'Terminal';
 
+  const settingsBtn = document.createElement('button');
+  settingsBtn.className = 'panel-settings-btn';
+  settingsBtn.textContent = '\u2699';
+  settingsBtn.title = 'Panel settings';
+  settingsBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    showPanelSettingsModal(panel);
+  });
+
   const closeBtn = document.createElement('button');
   closeBtn.className = 'panel-close-btn';
   closeBtn.textContent = '\u00d7';
   closeBtn.addEventListener('click', () => removePanel(panel.id));
 
   header.appendChild(typeLabel);
+  header.appendChild(settingsBtn);
   header.appendChild(closeBtn);
   el.appendChild(header);
 
@@ -152,7 +162,7 @@ function createPanelElement(panel) {
   // Focus tracking: clicking a panel focuses it
   el.addEventListener('mousedown', e => {
     // Don't steal focus when clicking close button
-    if (e.target.closest('.panel-close-btn')) return;
+    if (e.target.closest('.panel-close-btn') || e.target.closest('.panel-settings-btn')) return;
     setFocusedPanel(panel.id);
   });
 

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -339,6 +339,20 @@ body {
 
 .panel-close-btn:hover { color: #ff6b6b; background: #3a1a1a; }
 
+.panel-settings-btn {
+  background: none;
+  border: none;
+  color: #556;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 1px 3px;
+  border-radius: 3px;
+  transition: color 0.12s, background 0.12s;
+}
+
+.panel-settings-btn:hover { color: #ccc; background: #2a2a4e; }
+
 .panel.dragging {
   opacity: 0.5;
   z-index: 100;


### PR DESCRIPTION
Each panel (terminal, web, file) now has a gear icon in the header that opens a type-specific settings modal. Terminal panels can change working directory and startup command (respawns PTY), web panels can change URL (navigates webview), and file panels can change root directory (reloads tree). Settings persist across restarts.

#35 