### PR TITLE
feat: Open web links as new panels with Cmd+Click insert-right support

### DIFF
--- a/main.js
+++ b/main.js
@@ -442,10 +442,39 @@ app.whenReady().then(async () => {
         }
       });
 
+      contents.setWindowOpenHandler(({ url, disposition }) => {
+        debugLog('[setWindowOpenHandler] url:', url, 'disposition:', disposition);
+        if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) {
+          return { action: 'deny' };
+        }
+        const host = contents.hostWebContents;
+        if (host && !host.isDestroyed()) {
+          host.send('webview:open-in-new-panel', {
+            url,
+            sourceWebContentsId: contents.id,
+            disposition,
+          });
+        }
+        return { action: 'deny' };
+      });
+
       contents.on('context-menu', (event, params) => {
         const menuTemplate = [];
 
         if (params.linkURL) {
+          menuTemplate.push({
+            label: 'Open Link in New Panel',
+            click: () => {
+              const host = contents.hostWebContents;
+              if (host && !host.isDestroyed()) {
+                host.send('webview:open-in-new-panel', {
+                  url: params.linkURL,
+                  sourceWebContentsId: contents.id,
+                  disposition: 'new-window',
+                });
+              }
+            },
+          });
           menuTemplate.push({
             label: 'Copy Link Address',
             click: () => clipboard.writeText(params.linkURL),

--- a/preload.js
+++ b/preload.js
@@ -55,6 +55,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('webview:find', listener);
     return () => ipcRenderer.removeListener('webview:find', listener);
   },
+  onWebviewOpenInNewPanel: (callback) => {
+    const listener = (_, data) => callback(data);
+    ipcRenderer.on('webview:open-in-new-panel', listener);
+    return () => ipcRenderer.removeListener('webview:open-in-new-panel', listener);
+  },
   searchFindInPage: (webContentsId, text, options) =>
     ipcRenderer.invoke('search:findInPage', { webContentsId, text, options }),
   searchStopFindInPage: (webContentsId, action) =>

--- a/renderer/app.js
+++ b/renderer/app.js
@@ -256,6 +256,67 @@ async function addPanel(type) {
   saveState();
 }
 
+function addWebPanelAt(url, insertIndex) {
+  const group = getActiveGroup();
+  if (!group) return;
+
+  const globalWebCount = state.groups.flatMap(g => g.panels).filter(p => p.type === 'web').length;
+  if (globalWebCount >= MAX_WEB_PANELS) return;
+
+  const panel = {
+    id: generateId(),
+    type: 'web',
+    width: DEFAULT_WEB_WIDTH,
+    url: url || '',
+  };
+
+  const idx = Math.max(0, Math.min(insertIndex, group.panels.length));
+  group.panels.splice(idx, 0, panel);
+
+  const cached = getCachedContainer(state.activeGroupId);
+  if (cached) {
+    const panelEls = cached.querySelectorAll('.panel');
+    const addControls = cached.querySelector('.add-panel-controls');
+    const panelEl = createPanelElement(panel);
+    const resizeHandle = createResizeHandle(panel.id);
+
+    if (idx < panelEls.length) {
+      cached.insertBefore(panelEl, panelEls[idx]);
+      cached.insertBefore(resizeHandle, panelEls[idx]);
+    } else if (addControls) {
+      cached.insertBefore(panelEl, addControls);
+      cached.insertBefore(resizeHandle, addControls);
+    } else {
+      removeCachedGroup(state.activeGroupId);
+      renderPanelStrip();
+      saveState();
+      return;
+    }
+    renderStatusBar();
+  } else {
+    renderPanelStrip();
+  }
+
+  saveState();
+}
+
+function addWebPanelAfter(sourcePanelId, url) {
+  const group = getActiveGroup();
+  if (!group) return;
+  const sourceIndex = group.panels.findIndex(p => p.id === sourcePanelId);
+  if (sourceIndex === -1) {
+    addWebPanelAt(url, group.panels.length);
+  } else {
+    addWebPanelAt(url, sourceIndex + 1);
+  }
+}
+
+function addWebPanelAtEnd(url) {
+  const group = getActiveGroup();
+  if (!group) return;
+  addWebPanelAt(url, group.panels.length);
+}
+
 function removePanel(panelId) {
   const group = getActiveGroup();
   if (!group) return;

--- a/renderer/web-panel.js
+++ b/renderer/web-panel.js
@@ -16,6 +16,16 @@ if (window.electronAPI.onWebviewFind) {
     if (entry) entry.showSearch();
   });
 }
+if (window.electronAPI.onWebviewOpenInNewPanel) {
+  window.electronAPI.onWebviewOpenInNewPanel(({ url, sourceWebContentsId, disposition }) => {
+    const entry = webviewRegistry.get(sourceWebContentsId);
+    if (disposition === 'foreground-tab' && entry) {
+      addWebPanelAfter(entry.panelId, url);
+    } else {
+      addWebPanelAtEnd(url);
+    }
+  });
+}
 
 function renderWebPanel(panel, container) {
   const urlBar = document.createElement('div');


### PR DESCRIPTION
Intercept new-window requests (target="_blank", window.open(), Cmd+Click) in webview panels and open them as new web panels instead of dropping them. Cmd+Click inserts the new panel immediately right of the source panel, while other link opens append at the end. Also adds "Open Link in New Panel" to the right-click context menu.

Closes #43 