### PR TITLE
feat: Add resizable sidebar with drag handle

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -51,6 +51,7 @@ async function init() {
     if (!state.maxCachedGroups || state.maxCachedGroups === 5) state.maxCachedGroups = 20;
     if (!state.templates) state.templates = [];
     if (!state.urlHistory) state.urlHistory = [];
+    if (!state.sidebarWidth) state.sidebarWidth = 210;
     // Migrate: ensure all groups have lspServers
     for (const group of state.groups) {
       group.lspServers = group.lspServers || [];
@@ -63,11 +64,13 @@ async function init() {
     state = {
       activeGroupId: id,
       maxCachedGroups: 20,
+      sidebarWidth: 210,
       groups: [{ id, label: 'Work 1', panels: [], lspServers: [] }],
     };
   }
 
   renderSidebar();
+  document.getElementById('sidebar').style.width = state.sidebarWidth + 'px';
   renderPanelStrip();
 
   let windowResizeTimer = null;

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -11,6 +11,7 @@
 <body>
   <div id="app">
     <div id="sidebar"></div>
+    <div id="sidebar-resize-handle"></div>
     <div id="main">
       <div id="panel-strip"></div>
       <div id="status-bar"></div>

--- a/renderer/sidebar.js
+++ b/renderer/sidebar.js
@@ -73,3 +73,34 @@ function startRenameGroup(groupId, labelEl) {
   input.focus();
   input.select();
 }
+
+// ── Sidebar resize ───────────────────────────────
+document.addEventListener('DOMContentLoaded', () => {
+  const handle = document.getElementById('sidebar-resize-handle');
+  const sidebar = document.getElementById('sidebar');
+  if (!handle || !sidebar) return;
+
+  handle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = sidebar.offsetWidth;
+    handle.classList.add('active');
+
+    const onMove = (ev) => {
+      const newWidth = Math.max(150, Math.min(500, startW + (ev.clientX - startX)));
+      sidebar.style.width = newWidth + 'px';
+      state.sidebarWidth = newWidth;
+      fitVisibleTerminals(state.activeGroupId);
+    };
+
+    const onUp = () => {
+      handle.classList.remove('active');
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      saveState();
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  });
+});

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -22,12 +22,28 @@ body {
 
 #sidebar {
   width: 210px;
-  min-width: 210px;
+  min-width: 150px;
+  max-width: 500px;
   background: #16213e;
   border-right: 1px solid #0f3460;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  flex-shrink: 0;
+}
+
+#sidebar-resize-handle {
+  width: 4px;
+  min-width: 4px;
+  cursor: col-resize;
+  background: transparent;
+  transition: background 0.15s;
+  flex-shrink: 0;
+}
+
+#sidebar-resize-handle:hover,
+#sidebar-resize-handle.active {
+  background: #533483;
 }
 
 .sidebar-title {


### PR DESCRIPTION
Add a drag handle on the sidebar's right edge allowing users to resize it between 150px and 500px, preventing workspace name truncation. Width is persisted across sessions and terminals re-fit during resize.

Closes #41 