### PR TITLE
fix: Clean up previous drag state before starting a new panel drag

### DIFF
--- a/renderer/panel-drag.js
+++ b/renderer/panel-drag.js
@@ -11,6 +11,20 @@ function initPanelDrag(panelEl) {
   header.addEventListener('mousedown', e => {
     if (e.target.closest('.panel-close-btn') || e.target.closest('.panel-settings-btn')) return;
     e.preventDefault();
+
+    // Clean up any in-progress drag before starting a new one
+    if (dragState) {
+      if (dragState.started) {
+        dragState.panelEl.classList.remove('dragging');
+        if (dragState.indicator) {
+          dragState.indicator.remove();
+        }
+      }
+      document.removeEventListener('mousemove', onDragMove);
+      document.removeEventListener('mouseup', onDragEnd);
+      dragState = null;
+    }
+
     dragState = {
       panelEl,
       startX: e.clientX,


### PR DESCRIPTION
Prevents panels from getting stuck with the .dragging CSS class (opacity: 0.5, pointer-events: none) when a user starts dragging one panel and then clicks on a different panel's header.

Closes #51 