### PR TITLE
fix: Resolve horizontal scroll stuttering in panel strip

### DIFF
--- a/main.js
+++ b/main.js
@@ -288,7 +288,9 @@ ipcMain.on('auth:login-response', (_, { requestId, username, password, cancelled
   else callback(username, password);
 });
 
-app.disableHardwareAcceleration();
+// Re-enable GPU compositing (was disabled only to silence log noise in commit 79af0a5).
+// Suppress the cosmetic GPU compositor warnings via log-level flag.
+app.commandLine.appendSwitch('log-level', '3');
 
 app.whenReady().then(async () => {
   debugLog('whenReady callback entered');

--- a/renderer/panel-strip.js
+++ b/renderer/panel-strip.js
@@ -9,6 +9,19 @@ document.addEventListener('DOMContentLoaded', () => {
         setFocusedPanel(null);
       }
     });
+
+    // Disable pointer-events during scroll to avoid hit-testing overhead
+    let scrollTimeout = null;
+    strip.addEventListener('scroll', () => {
+      if (!scrollTimeout) {
+        strip.style.pointerEvents = 'none';
+      }
+      clearTimeout(scrollTimeout);
+      scrollTimeout = setTimeout(() => {
+        strip.style.pointerEvents = '';
+        scrollTimeout = null;
+      }, 150);
+    }, { passive: true });
   }
 });
 

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -175,6 +175,7 @@ body {
   padding: 12px 12px 12px 12px;
   gap: 0;
   position: relative;
+  will-change: scroll-position;
 }
 
 /* ── Status bar ─────────────────────────────────── */
@@ -257,11 +258,13 @@ body {
   overflow: hidden;
   flex-shrink: 0;
   min-width: 300px;
+  contain: layout style paint;
 }
 
 .panel-focused {
   box-shadow: 0 0 12px 2px rgba(83, 52, 131, 0.35);
   border-color: #533483;
+  will-change: transform;
 }
 
 /* ── Panel search bar ───────────────────────────── */


### PR DESCRIPTION
Re-enable hardware acceleration (was disabled only to silence GPU log noise), add CSS containment on panels, compositor hints on scroll container and focused panels, and disable pointer-events during scroll to reduce hit-testing overhead.

Closes #53 