### PR TITLE
fix: Remove pointer-events hack that blocked scroll input after flick…

### DIFF
--- a/renderer/panel-strip.js
+++ b/renderer/panel-strip.js
@@ -9,19 +9,6 @@ document.addEventListener('DOMContentLoaded', () => {
         setFocusedPanel(null);
       }
     });
-
-    // Disable pointer-events during scroll to avoid hit-testing overhead
-    let scrollTimeout = null;
-    strip.addEventListener('scroll', () => {
-      if (!scrollTimeout) {
-        strip.style.pointerEvents = 'none';
-      }
-      clearTimeout(scrollTimeout);
-      scrollTimeout = setTimeout(() => {
-        strip.style.pointerEvents = '';
-        scrollTimeout = null;
-      }, 150);
-    }, { passive: true });
   }
 });
 


### PR DESCRIPTION
… gesture

The scroll listener disabled pointer-events during momentum scrolling, preventing new scroll gestures for 2-5 seconds on macOS. Existing CSS optimizations (will-change, contain, GPU acceleration) already handle scroll performance.

Closes #55 