### PR TITLE
feat: Add profile feature to segment worklayers into independent prof…

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -11,7 +11,7 @@ const MAX_URL_HISTORY = 100;
 const MAX_URL_COUNT = 10;
 const URL_DECAY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
 
-let state = { activeGroupId: null, groups: [], templates: [], urlHistory: [] };
+let state = { activeProfileId: null, profiles: [] };
 
 // Map<panelId, { terminal, fitAddon, cleanup, termId }>
 const activeTerminals = new Map();
@@ -46,33 +46,78 @@ function setFocusedPanel(panelId) {
   }
 }
 
+function getActiveProfile() {
+  return state.profiles.find(p => p.id === state.activeProfileId) || null;
+}
+
+function getActiveGroupId() {
+  const profile = getActiveProfile();
+  return profile ? profile.activeGroupId : null;
+}
+
+function migrateProfile(profile) {
+  if (!profile.templates) profile.templates = [];
+  if (!profile.urlHistory) profile.urlHistory = [];
+  for (const entry of profile.urlHistory) {
+    if (!entry.count) entry.count = 1;
+    if (!entry.lastAccessed) entry.lastAccessed = entry.timestamp || Date.now();
+  }
+  for (const group of profile.groups) {
+    group.lspServers = group.lspServers || [];
+  }
+  if (!profile.groups.find(g => g.id === profile.activeGroupId)) {
+    profile.activeGroupId = profile.groups[0]?.id || null;
+  }
+}
+
 async function init() {
   const saved = await window.electronAPI.loadState();
-  if (saved && Array.isArray(saved.groups) && saved.groups.length > 0) {
+
+  if (saved && Array.isArray(saved.profiles) && saved.profiles.length > 0) {
+    // New format
     state = saved;
     if (!state.maxCachedGroups || state.maxCachedGroups === 5) state.maxCachedGroups = 20;
-    if (!state.templates) state.templates = [];
-    if (!state.urlHistory) state.urlHistory = [];
     if (!state.sidebarWidth) state.sidebarWidth = 210;
-    // Migrate: ensure all URL history entries have count/lastAccessed
-    for (const entry of state.urlHistory) {
-      if (!entry.count) entry.count = 1;
-      if (!entry.lastAccessed) entry.lastAccessed = entry.timestamp || Date.now();
+    for (const profile of state.profiles) {
+      migrateProfile(profile);
     }
-    // Migrate: ensure all groups have lspServers
-    for (const group of state.groups) {
-      group.lspServers = group.lspServers || [];
+    if (!state.profiles.find(p => p.id === state.activeProfileId)) {
+      state.activeProfileId = state.profiles[0].id;
     }
-    if (!state.groups.find(g => g.id === state.activeGroupId)) {
-      state.activeGroupId = state.groups[0].id;
-    }
-  } else {
-    const id = generateId();
+  } else if (saved && Array.isArray(saved.groups) && saved.groups.length > 0) {
+    // Old format — wrap into a Default profile
+    const profileId = generateId();
+    const profile = {
+      id: profileId,
+      name: 'Default',
+      activeGroupId: saved.activeGroupId,
+      groups: saved.groups,
+      templates: saved.templates || [],
+      urlHistory: saved.urlHistory || [],
+    };
+    migrateProfile(profile);
     state = {
-      activeGroupId: id,
+      activeProfileId: profileId,
+      profiles: [profile],
+      maxCachedGroups: saved.maxCachedGroups || 20,
+      sidebarWidth: saved.sidebarWidth || 210,
+    };
+  } else {
+    // Fresh state
+    const groupId = generateId();
+    const profileId = generateId();
+    state = {
+      activeProfileId: profileId,
       maxCachedGroups: 20,
       sidebarWidth: 210,
-      groups: [{ id, label: 'Work 1', panels: [], lspServers: [] }],
+      profiles: [{
+        id: profileId,
+        name: 'Default',
+        activeGroupId: groupId,
+        groups: [{ id: groupId, label: 'Work 1', panels: [], lspServers: [] }],
+        templates: [],
+        urlHistory: [],
+      }],
     };
   }
 
@@ -84,8 +129,9 @@ async function init() {
   window.addEventListener('resize', () => {
     clearTimeout(windowResizeTimer);
     windowResizeTimer = setTimeout(() => {
-      if (state.activeGroupId) {
-        fitVisibleTerminals(state.activeGroupId);
+      const activeGroupId = getActiveGroupId();
+      if (activeGroupId) {
+        fitVisibleTerminals(activeGroupId);
       }
     }, 100);
   });
@@ -103,21 +149,27 @@ function generateId() {
 }
 
 function getActiveGroup() {
-  return state.groups.find(g => g.id === state.activeGroupId) || null;
+  const profile = getActiveProfile();
+  if (!profile) return null;
+  return profile.groups.find(g => g.id === profile.activeGroupId) || null;
 }
 
 // ── Group operations ──────────────────────────────
 
 function addGroup() {
+  const profile = getActiveProfile();
+  if (!profile) return;
   const id = generateId();
-  state.groups.push({ id, label: `Work ${state.groups.length + 1}`, panels: [], lspServers: [] });
-  state.activeGroupId = id;
+  profile.groups.push({ id, label: `Work ${profile.groups.length + 1}`, panels: [], lspServers: [] });
+  profile.activeGroupId = id;
   saveState();
   renderSidebar();
   renderPanelStrip();
 }
 
 function addGroupWithPanels(name, panelConfigs) {
+  const profile = getActiveProfile();
+  if (!profile) return;
   const id = generateId();
   const widths = { terminal: DEFAULT_TERM_WIDTH, web: DEFAULT_WEB_WIDTH, file: DEFAULT_FILE_WIDTH };
 
@@ -139,42 +191,48 @@ function addGroupWithPanels(name, panelConfigs) {
     return panel;
   });
 
-  state.groups.push({ id, label: name || `Work ${state.groups.length + 1}`, panels, lspServers: [] });
-  state.activeGroupId = id;
+  profile.groups.push({ id, label: name || `Work ${profile.groups.length + 1}`, panels, lspServers: [] });
+  profile.activeGroupId = id;
   saveState();
   renderSidebar();
   renderPanelStrip(false);
 }
 
 function saveTemplate(name, panelConfigs) {
+  const profile = getActiveProfile();
+  if (!profile) return null;
   const template = {
     id: generateId(),
     name,
     panels: panelConfigs.map(config => ({ ...config })),
   };
-  state.templates.push(template);
+  profile.templates.push(template);
   saveState();
   return template;
 }
 
 function deleteTemplate(templateId) {
-  state.templates = state.templates.filter(t => t.id !== templateId);
+  const profile = getActiveProfile();
+  if (!profile) return;
+  profile.templates = profile.templates.filter(t => t.id !== templateId);
   saveState();
 }
 
 function deleteGroup(groupId) {
-  const group = state.groups.find(g => g.id === groupId);
+  const profile = getActiveProfile();
+  if (!profile) return;
+  const group = profile.groups.find(g => g.id === groupId);
   if (group) killGroupTerminals(group);
   removeCachedGroup(groupId);
 
-  state.groups = state.groups.filter(g => g.id !== groupId);
+  profile.groups = profile.groups.filter(g => g.id !== groupId);
 
-  if (state.groups.length === 0) {
+  if (profile.groups.length === 0) {
     const id = generateId();
-    state.groups.push({ id, label: 'Work 1', panels: [], lspServers: [] });
+    profile.groups.push({ id, label: 'Work 1', panels: [], lspServers: [] });
   }
-  if (!state.groups.find(g => g.id === state.activeGroupId)) {
-    state.activeGroupId = state.groups[0].id;
+  if (!profile.groups.find(g => g.id === profile.activeGroupId)) {
+    profile.activeGroupId = profile.groups[0].id;
   }
 
   saveState();
@@ -183,7 +241,9 @@ function deleteGroup(groupId) {
 }
 
 function renameGroup(groupId, newLabel) {
-  const group = state.groups.find(g => g.id === groupId);
+  const profile = getActiveProfile();
+  if (!profile) return;
+  const group = profile.groups.find(g => g.id === groupId);
   if (group && newLabel.trim()) {
     group.label = newLabel.trim();
     saveState();
@@ -192,9 +252,10 @@ function renameGroup(groupId, newLabel) {
 }
 
 function selectGroup(groupId) {
-  if (state.activeGroupId === groupId) return;
+  const profile = getActiveProfile();
+  if (!profile || profile.activeGroupId === groupId) return;
   setFocusedPanel(null);
-  state.activeGroupId = groupId;
+  profile.activeGroupId = groupId;
   saveState();
   renderSidebar();
   renderPanelStrip();
@@ -219,10 +280,12 @@ async function addPanel(type) {
   const group = getActiveGroup();
   if (!group) return;
 
+  const profile = getActiveProfile();
+  if (!profile) return;
   const maxLimits = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
   const maxForType = maxLimits[type];
-  const globalCount = state.groups.flatMap(g => g.panels).filter(p => p.type === type).length;
-  if (maxForType && globalCount >= maxForType) return;
+  const profileCount = profile.groups.flatMap(g => g.panels).filter(p => p.type === type).length;
+  if (maxForType && profileCount >= maxForType) return;
 
   let extraProps = {};
   if (type === 'web') {
@@ -244,7 +307,8 @@ async function addPanel(type) {
   group.panels.push(panel);
 
   // Surgically insert into cached DOM to avoid destroying existing terminals
-  const cached = getCachedContainer(state.activeGroupId);
+  const activeGId = getActiveGroupId();
+  const cached = getCachedContainer(activeGId);
   if (cached) {
     const addControls = cached.querySelector('.add-panel-controls');
     if (addControls) {
@@ -256,7 +320,7 @@ async function addPanel(type) {
       renderStatusBar();
     } else {
       // Was showing empty state — rebuild entirely
-      removeCachedGroup(state.activeGroupId);
+      removeCachedGroup(activeGId);
       renderPanelStrip();
     }
   } else {
@@ -270,8 +334,10 @@ function addWebPanelAt(url, insertIndex) {
   const group = getActiveGroup();
   if (!group) return;
 
-  const globalWebCount = state.groups.flatMap(g => g.panels).filter(p => p.type === 'web').length;
-  if (globalWebCount >= MAX_WEB_PANELS) return;
+  const profile = getActiveProfile();
+  if (!profile) return;
+  const profileWebCount = profile.groups.flatMap(g => g.panels).filter(p => p.type === 'web').length;
+  if (profileWebCount >= MAX_WEB_PANELS) return;
 
   const panel = {
     id: generateId(),
@@ -283,7 +349,8 @@ function addWebPanelAt(url, insertIndex) {
   const idx = Math.max(0, Math.min(insertIndex, group.panels.length));
   group.panels.splice(idx, 0, panel);
 
-  const cached = getCachedContainer(state.activeGroupId);
+  const activeGId = getActiveGroupId();
+  const cached = getCachedContainer(activeGId);
   if (cached) {
     const panelEls = cached.querySelectorAll('.panel');
     const addControls = cached.querySelector('.add-panel-controls');
@@ -297,7 +364,7 @@ function addWebPanelAt(url, insertIndex) {
       cached.insertBefore(panelEl, addControls);
       cached.insertBefore(resizeHandle, addControls);
     } else {
-      removeCachedGroup(state.activeGroupId);
+      removeCachedGroup(activeGId);
       renderPanelStrip();
       saveState();
       return;
@@ -346,7 +413,8 @@ function removePanel(panelId) {
   group.panels = group.panels.filter(p => p.id !== panelId);
 
   // Surgically remove from cached DOM to avoid destroying existing terminals
-  const cached = getCachedContainer(state.activeGroupId);
+  const activeGId = getActiveGroupId();
+  const cached = getCachedContainer(activeGId);
   if (cached && group.panels.length > 0) {
     const panelEl = cached.querySelector(`[data-panel-id="${panelId}"]`);
     if (panelEl) {
@@ -360,7 +428,7 @@ function removePanel(panelId) {
     renderStatusBar();
   } else {
     // Group is empty or no cache — rebuild
-    removeCachedGroup(state.activeGroupId);
+    removeCachedGroup(activeGId);
     renderPanelStrip();
   }
 
@@ -468,27 +536,31 @@ function rebuildFilePanel(panelId, panel) {
 
 function addToUrlHistory(url, title) {
   if (!url || url === 'about:blank' || url.startsWith('data:')) return;
-  const idx = state.urlHistory.findIndex(e => e.url === url);
+  const profile = getActiveProfile();
+  if (!profile) return;
+  const idx = profile.urlHistory.findIndex(e => e.url === url);
   if (idx !== -1) {
-    const entry = state.urlHistory[idx];
+    const entry = profile.urlHistory[idx];
     entry.count = Math.min((entry.count || 1) + 1, MAX_URL_COUNT);
     entry.lastAccessed = Date.now();
     if (title) entry.title = title;
-    state.urlHistory.splice(idx, 1);
-    state.urlHistory.unshift(entry);
+    profile.urlHistory.splice(idx, 1);
+    profile.urlHistory.unshift(entry);
   } else {
-    state.urlHistory.unshift({ url, title: title || '', timestamp: Date.now(), count: 1, lastAccessed: Date.now() });
+    profile.urlHistory.unshift({ url, title: title || '', timestamp: Date.now(), count: 1, lastAccessed: Date.now() });
   }
-  if (state.urlHistory.length > MAX_URL_HISTORY) {
-    state.urlHistory = state.urlHistory.slice(0, MAX_URL_HISTORY);
+  if (profile.urlHistory.length > MAX_URL_HISTORY) {
+    profile.urlHistory = profile.urlHistory.slice(0, MAX_URL_HISTORY);
   }
   saveState();
 }
 
 function getFilteredUrlHistory(query) {
   applyUrlHistoryDecay();
+  const profile = getActiveProfile();
+  if (!profile) return [];
   const q = (query || '').toLowerCase().trim();
-  let results = state.urlHistory;
+  let results = profile.urlHistory;
   if (q) {
     results = results.filter(e => e.url.toLowerCase().includes(q) || (e.title && e.title.toLowerCase().includes(q)));
   }
@@ -505,8 +577,10 @@ function applyUrlHistoryDecay() {
   const now = Date.now();
   if (now - lastDecayCheck < 60000) return;
   lastDecayCheck = now;
+  const profile = getActiveProfile();
+  if (!profile) return;
   let changed = false;
-  state.urlHistory = state.urlHistory.filter(entry => {
+  profile.urlHistory = profile.urlHistory.filter(entry => {
     const lastAccessed = entry.lastAccessed || entry.timestamp || 0;
     const weeks = Math.floor((now - lastAccessed) / URL_DECAY_INTERVAL_MS);
     if (weeks > 0) {
@@ -517,6 +591,103 @@ function applyUrlHistoryDecay() {
     return true;
   });
   if (changed) saveState();
+}
+
+// ── Profile operations ────────────────────────────
+
+function teardownCurrentProfile() {
+  const profile = getActiveProfile();
+  if (!profile) return;
+
+  // Kill all terminals and editors in every group of the current profile
+  for (const group of profile.groups) {
+    killGroupTerminals(group);
+  }
+
+  // Clear DOM cache
+  groupDOMCache.forEach((el) => el.remove());
+  groupDOMCache.clear();
+  lruOrder.length = 0;
+
+  // Clear active maps
+  activeTerminals.clear();
+  activeEditors.clear();
+  activeLspServers.clear();
+
+  // Destroy all panel searches
+  for (const [panelId] of activePanelSearches) {
+    destroyPanelSearch(panelId);
+  }
+
+  // Clear webview registry
+  webviewRegistry.clear();
+
+  // Disconnect LSP
+  if (typeof disconnectAllLsp === 'function') disconnectAllLsp();
+
+  // Reset focus
+  setFocusedPanel(null);
+}
+
+function addProfile(name) {
+  const groupId = generateId();
+  const profileId = generateId();
+  const profile = {
+    id: profileId,
+    name: name || 'New Profile',
+    activeGroupId: groupId,
+    groups: [{ id: groupId, label: 'Work 1', panels: [], lspServers: [] }],
+    templates: [],
+    urlHistory: [],
+  };
+
+  teardownCurrentProfile();
+  state.profiles.push(profile);
+  state.activeProfileId = profileId;
+  saveState();
+  renderSidebar();
+  renderPanelStrip();
+}
+
+function switchProfile(profileId) {
+  if (state.activeProfileId === profileId) return;
+  if (!state.profiles.find(p => p.id === profileId)) return;
+
+  teardownCurrentProfile();
+  state.activeProfileId = profileId;
+  saveState();
+  renderSidebar();
+  renderPanelStrip();
+}
+
+function renameProfile(profileId, newName) {
+  const profile = state.profiles.find(p => p.id === profileId);
+  if (profile && newName.trim()) {
+    profile.name = newName.trim();
+    saveState();
+    renderSidebar();
+  }
+}
+
+function deleteProfile(profileId) {
+  if (state.profiles.length <= 1) return;
+  const profile = state.profiles.find(p => p.id === profileId);
+  if (!profile) return;
+
+  // If deleting active profile, switch to another first
+  if (state.activeProfileId === profileId) {
+    const other = state.profiles.find(p => p.id !== profileId);
+    if (other) switchProfile(other.id);
+  }
+
+  // Now teardown and remove
+  for (const group of profile.groups) {
+    killGroupTerminals(group);
+    removeCachedGroup(group.id);
+  }
+  state.profiles = state.profiles.filter(p => p.id !== profileId);
+  saveState();
+  renderSidebar();
 }
 
 // ── Global Cmd+F / Ctrl+F handler ────────────────

--- a/renderer/group-cache.js
+++ b/renderer/group-cache.js
@@ -24,7 +24,8 @@ function evictLRU() {
       el.remove();
       groupDOMCache.delete(evictId);
     }
-    const group = state.groups.find(g => g.id === evictId);
+    const profile = getActiveProfile();
+    const group = profile ? profile.groups.find(g => g.id === evictId) : null;
     if (group) killGroupTerminals(group);
     evicted = true;
   }
@@ -53,7 +54,8 @@ function removeCachedGroup(groupId) {
 }
 
 function fitVisibleTerminals(groupId) {
-  const group = state.groups.find(g => g.id === groupId);
+  const profile = getActiveProfile();
+  const group = profile ? profile.groups.find(g => g.id === groupId) : null;
   if (!group) return;
   group.panels.forEach(p => {
     if (p.type === 'terminal' && activeTerminals.has(p.id)) {

--- a/renderer/panel-drag.js
+++ b/renderer/panel-drag.js
@@ -53,7 +53,7 @@ function onDragMove(e) {
     const indicator = document.createElement('div');
     indicator.className = 'drop-indicator';
     dragState.indicator = indicator;
-    const container = getCachedContainer(state.activeGroupId);
+    const container = getCachedContainer(getActiveGroupId());
     (container || document.getElementById('panel-strip')).appendChild(indicator);
 
     startAutoScroll();
@@ -65,7 +65,7 @@ function onDragMove(e) {
 function updateDropIndicator() {
   if (!dragState || !dragState.started) return;
 
-  const container = getCachedContainer(state.activeGroupId);
+  const container = getCachedContainer(getActiveGroupId());
   const scope = container || document.getElementById('panel-strip');
   const panels = Array.from(scope.querySelectorAll('.panel:not(.dragging)'));
 
@@ -148,7 +148,7 @@ function onDragEnd() {
       dragState.indicator.remove();
     }
 
-    const container = getCachedContainer(state.activeGroupId);
+    const container = getCachedContainer(getActiveGroupId());
     const scope = container || document.getElementById('panel-strip');
     const panelEl = dragState.panelEl;
     const panelId = panelEl.dataset.panelId;
@@ -200,7 +200,7 @@ function syncPanelOrder() {
   const group = getActiveGroup();
   if (!group) return;
 
-  const container = getCachedContainer(state.activeGroupId);
+  const container = getCachedContainer(getActiveGroupId());
   const scope = container || document.getElementById('panel-strip');
   const domPanelIds = Array.from(scope.querySelectorAll('[data-panel-id]'))
     .map(el => el.dataset.panelId);

--- a/renderer/panel-strip.js
+++ b/renderer/panel-strip.js
@@ -192,7 +192,7 @@ function createResizeHandle(panelId) {
       const newWidth = Math.max(300, startWidth + (e.clientX - startX));
       updatePanelWidth(panelId, newWidth);
 
-      const container = getCachedContainer(state.activeGroupId);
+      const container = getCachedContainer(getActiveGroupId());
       const panelEl = container
         ? container.querySelector(`[data-panel-id="${panelId}"]`)
         : document.querySelector(`[data-panel-id="${panelId}"]`);

--- a/renderer/sidebar.js
+++ b/renderer/sidebar.js
@@ -4,17 +4,120 @@ function renderSidebar() {
   const sidebar = document.getElementById('sidebar');
   sidebar.innerHTML = '';
 
+  const profile = getActiveProfile();
+
+  // ── Profile selector ──────────────────────────
+  const profileSection = document.createElement('div');
+  profileSection.className = 'profile-section';
+
+  const profileSelect = document.createElement('select');
+  profileSelect.className = 'profile-select';
+  state.profiles.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.name;
+    if (p.id === state.activeProfileId) opt.selected = true;
+    profileSelect.appendChild(opt);
+  });
+  profileSelect.addEventListener('change', () => {
+    switchProfile(profileSelect.value);
+  });
+
+  const profileActions = document.createElement('div');
+  profileActions.className = 'profile-actions';
+
+  const addProfileBtn = document.createElement('button');
+  addProfileBtn.className = 'profile-action-btn';
+  addProfileBtn.textContent = '+';
+  addProfileBtn.title = 'Add profile';
+  addProfileBtn.addEventListener('click', () => {
+    // Replace the select with an inline input for naming the new profile
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'profile-rename-input';
+    input.placeholder = 'New profile name';
+    profileSelect.replaceWith(input);
+    input.focus();
+
+    const finish = () => {
+      const name = input.value.trim();
+      if (name) {
+        addProfile(name);
+      } else {
+        // Cancelled — re-render to restore the select
+        renderSidebar();
+      }
+    };
+    input.addEventListener('blur', finish);
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') input.blur();
+      if (e.key === 'Escape') { input.value = ''; input.blur(); }
+    });
+  });
+
+  const renameProfileBtn = document.createElement('button');
+  renameProfileBtn.className = 'profile-action-btn';
+  renameProfileBtn.textContent = '\u270E';
+  renameProfileBtn.title = 'Rename profile';
+  renameProfileBtn.addEventListener('click', () => {
+    if (!profile) return;
+    // Replace the select with an inline input for renaming
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'profile-rename-input';
+    input.value = profile.name;
+    profileSelect.replaceWith(input);
+    input.focus();
+    input.select();
+
+    const finish = () => {
+      const newName = input.value.trim() || profile.name;
+      renameProfile(profile.id, newName);
+    };
+    input.addEventListener('blur', finish);
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') input.blur();
+      if (e.key === 'Escape') { input.value = profile.name; input.blur(); }
+    });
+  });
+
+  const deleteProfileBtn = document.createElement('button');
+  deleteProfileBtn.className = 'profile-action-btn profile-action-btn-danger';
+  deleteProfileBtn.textContent = '\u00d7';
+  deleteProfileBtn.title = 'Delete profile';
+  if (state.profiles.length <= 1) {
+    deleteProfileBtn.disabled = true;
+    deleteProfileBtn.classList.add('profile-action-btn-disabled');
+  }
+  deleteProfileBtn.addEventListener('click', () => {
+    if (!profile || state.profiles.length <= 1) return;
+    if (confirm(`Delete profile "${profile.name}" and all its workspaces?`)) {
+      deleteProfile(profile.id);
+    }
+  });
+
+  profileActions.appendChild(addProfileBtn);
+  profileActions.appendChild(renameProfileBtn);
+  profileActions.appendChild(deleteProfileBtn);
+
+  profileSection.appendChild(profileSelect);
+  profileSection.appendChild(profileActions);
+  sidebar.appendChild(profileSection);
+
+  // ── Workspace title ───────────────────────────
   const title = document.createElement('div');
   title.className = 'sidebar-title';
   title.textContent = 'Workspaces';
   sidebar.appendChild(title);
 
+  if (!profile) return;
+
   const list = document.createElement('div');
   list.className = 'group-list';
 
-  state.groups.forEach(group => {
+  profile.groups.forEach(group => {
     const item = document.createElement('div');
-    item.className = 'group-item' + (group.id === state.activeGroupId ? ' active' : '');
+    item.className = 'group-item' + (group.id === profile.activeGroupId ? ' active' : '');
 
     const label = document.createElement('span');
     label.className = 'group-label';
@@ -30,7 +133,7 @@ function renderSidebar() {
 
     const del = document.createElement('button');
     del.className = 'group-delete-btn';
-    del.textContent = '×';
+    del.textContent = '\u00d7';
     del.title = 'Delete workspace';
     del.addEventListener('click', e => {
       e.stopPropagation();
@@ -90,7 +193,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const newWidth = Math.max(150, Math.min(500, startW + (ev.clientX - startX)));
       sidebar.style.width = newWidth + 'px';
       state.sidebarWidth = newWidth;
-      fitVisibleTerminals(state.activeGroupId);
+      const activeGId = getActiveGroupId();
+      if (activeGId) fitVisibleTerminals(activeGId);
     };
 
     const onUp = () => {

--- a/renderer/status-bar.js
+++ b/renderer/status-bar.js
@@ -4,7 +4,8 @@ function renderStatusBar() {
   const bar = document.getElementById('status-bar');
   if (!bar) return;
 
-  const allPanels = state.groups.flatMap(g => g.panels);
+  const profile = getActiveProfile();
+  const allPanels = profile ? profile.groups.flatMap(g => g.panels) : [];
 
   const types = [
     { type: 'terminal', label: 'Terminal', max: MAX_TERMINAL_PANELS },
@@ -12,13 +13,15 @@ function renderStatusBar() {
     { type: 'file', label: 'Files', max: MAX_FILE_PANELS },
   ];
 
-  bar.innerHTML = types.map(({ type, label, max }) => {
+  const profileLabel = profile ? `<span class="status-bar-item status-bar-profile">${profile.name}</span>` : '';
+
+  bar.innerHTML = profileLabel + types.map(({ type, label, max }) => {
     const count = allPanels.filter(p => p.type === type).length;
     if (type === 'terminal') {
       const activeCount = activeTerminals.size;
       return `<span class="status-bar-item">` +
         `<span class="status-bar-dot ${type}"></span>` +
-        `${label} ${activeCount} active · ${count} / ${max}` +
+        `${label} ${activeCount} active \u00b7 ${count} / ${max}` +
         `</span>`;
     }
     return `<span class="status-bar-item">` +

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -46,6 +46,89 @@ body {
   background: #533483;
 }
 
+/* ── Profile selector ─────────────────────────────── */
+
+.profile-section {
+  display: flex;
+  align-items: center;
+  padding: 8px 8px 6px;
+  gap: 6px;
+  border-bottom: 1px solid #0f3460;
+  flex-shrink: 0;
+}
+
+.profile-select {
+  flex: 1;
+  background: #12121e;
+  border: 1px solid #334;
+  color: #ccc;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  outline: none;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.profile-select:focus {
+  border-color: #533483;
+}
+
+.profile-rename-input {
+  flex: 1;
+  background: #0f3460;
+  border: 1px solid #533483;
+  color: #e0e0e0;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  outline: none;
+  min-width: 0;
+}
+
+.profile-actions {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.profile-action-btn {
+  background: none;
+  border: 1px solid #334;
+  color: #889;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  line-height: 1.2;
+  transition: all 0.12s;
+}
+
+.profile-action-btn:hover {
+  border-color: #533483;
+  color: #ccc;
+  background: #1e1e3e;
+}
+
+.profile-action-btn-danger:hover {
+  color: #ff6b6b;
+  background: #3a1a1a;
+  border-color: #833;
+}
+
+.profile-action-btn-disabled {
+  opacity: 0.3;
+  cursor: default;
+  pointer-events: none;
+}
+
+/* ── Status bar profile label ────────────────────── */
+
+.status-bar-profile {
+  color: #e0d0ff;
+  font-weight: 600;
+}
+
 .sidebar-title {
   padding: 14px 12px 10px;
   font-size: 10px;

--- a/renderer/web-panel.js
+++ b/renderer/web-panel.js
@@ -335,10 +335,13 @@ function renderWebPanel(panel, container) {
     // Update the title in URL history for this URL
     const currentUrl = urlInput.value;
     if (e.title && currentUrl) {
-      const entry = state.urlHistory.find(h => h.url === currentUrl);
-      if (entry) {
-        entry.title = e.title;
-        saveState();
+      const profile = getActiveProfile();
+      if (profile) {
+        const entry = profile.urlHistory.find(h => h.url === currentUrl);
+        if (entry) {
+          entry.title = e.title;
+          saveState();
+        }
       }
     }
   });

--- a/renderer/workspace-modal.js
+++ b/renderer/workspace-modal.js
@@ -16,8 +16,10 @@ function showWorkspaceModal() {
   header.textContent = 'New Workspace';
   modal.appendChild(header);
 
+  const profile = getActiveProfile();
+
   // Template selector
-  if (state.templates.length > 0) {
+  if (profile && profile.templates.length > 0) {
     const templateSection = document.createElement('div');
     templateSection.className = 'modal-template-section';
 
@@ -37,7 +39,7 @@ function showWorkspaceModal() {
     emptyOpt.textContent = '-- None --';
     templateSelect.appendChild(emptyOpt);
 
-    state.templates.forEach(t => {
+    profile.templates.forEach(t => {
       const opt = document.createElement('option');
       opt.value = t.id;
       opt.textContent = `${t.name} (${t.panels.length} panel${t.panels.length !== 1 ? 's' : ''})`;
@@ -53,7 +55,7 @@ function showWorkspaceModal() {
       const templateId = templateSelect.value;
       deleteTemplateBtn.style.display = templateId ? '' : 'none';
       if (templateId) {
-        const template = state.templates.find(t => t.id === templateId);
+        const template = profile.templates.find(t => t.id === templateId);
         if (template) {
           nameInput.value = template.name;
           panelRows = template.panels.map(p => ({ ...p }));
@@ -65,7 +67,7 @@ function showWorkspaceModal() {
     deleteTemplateBtn.addEventListener('click', () => {
       const templateId = templateSelect.value;
       if (!templateId) return;
-      const template = state.templates.find(t => t.id === templateId);
+      const template = profile.templates.find(t => t.id === templateId);
       if (template && confirm(`Delete template "${template.name}"?`)) {
         deleteTemplate(templateId);
         // Remove from select
@@ -74,7 +76,7 @@ function showWorkspaceModal() {
         templateSelect.value = '';
         deleteTemplateBtn.style.display = 'none';
         // Hide section if no templates left
-        if (state.templates.length === 0) {
+        if (profile.templates.length === 0) {
           templateSection.style.display = 'none';
         }
       }
@@ -95,7 +97,7 @@ function showWorkspaceModal() {
   const nameInput = document.createElement('input');
   nameInput.type = 'text';
   nameInput.className = 'modal-input';
-  nameInput.placeholder = `Work ${state.groups.length + 1}`;
+  nameInput.placeholder = `Work ${profile ? profile.groups.length + 1 : 1}`;
   nameSection.appendChild(nameLabel);
   nameSection.appendChild(nameInput);
   modal.appendChild(nameSection);
@@ -335,8 +337,8 @@ function showWorkspaceModal() {
     if (panelRows.length === 0) {
       addGroup();
       // Rename it if a name was provided
-      if (nameInput.value.trim()) {
-        const group = state.groups[state.groups.length - 1];
+      if (nameInput.value.trim() && profile) {
+        const group = profile.groups[profile.groups.length - 1];
         group.label = nameInput.value.trim();
         saveState();
         renderSidebar();


### PR DESCRIPTION
…iles

Each profile has its own set of workspaces, templates, and URL history. Switching profiles tears down all terminals, DOM cache, and editors, then loads the new profile fresh. Old state format is auto-migrated into a "Default" profile. Profile selector UI added to the sidebar with add, rename, and delete actions using inline inputs.

Closes #64 