### PR TITLE
feat: Improve panel resize UX with wider handles, rAF throttling, and…

### DIFF
--- a/renderer/panel-strip.js
+++ b/renderer/panel-strip.js
@@ -187,16 +187,17 @@ function createResizeHandle(panelId) {
     startWidth = panel.width;
 
     handle.classList.add('active');
+    document.body.classList.add('resizing');
 
-    const onMove = e => {
-      const newWidth = Math.max(300, startWidth + (e.clientX - startX));
-      updatePanelWidth(panelId, newWidth);
+    let latestWidth = startWidth;
+    let rafId = null;
 
+    const applyDOM = () => {
       const container = getCachedContainer(getActiveGroupId());
       const panelEl = container
         ? container.querySelector(`[data-panel-id="${panelId}"]`)
         : document.querySelector(`[data-panel-id="${panelId}"]`);
-      if (panelEl) panelEl.style.width = newWidth + 'px';
+      if (panelEl) panelEl.style.width = latestWidth + 'px';
 
       if (activeTerminals.has(panelId)) {
         const { fitAddon } = activeTerminals.get(panelId);
@@ -210,17 +211,69 @@ function createResizeHandle(panelId) {
           try { editor.layout(); } catch (e) {}
         }
       }
+      rafId = null;
+    };
+
+    const onMove = e => {
+      latestWidth = Math.max(300, startWidth + (e.clientX - startX));
+      updatePanelWidth(panelId, latestWidth);
+
+      if (!rafId) {
+        rafId = requestAnimationFrame(applyDOM);
+      }
     };
 
     const onUp = () => {
       handle.classList.remove('active');
+      document.body.classList.remove('resizing');
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      applyDOM();
       saveState();
     };
 
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
+  });
+
+  handle.addEventListener('dblclick', e => {
+    e.preventDefault();
+    const group = getActiveGroup();
+    const panel = group.panels.find(p => p.id === panelId);
+    if (!panel) return;
+
+    const strip = document.getElementById('panel-strip');
+    const maxWidth = strip.clientWidth - 40;
+    const newWidth = Math.min(panel.width * 2, maxWidth);
+    updatePanelWidth(panelId, newWidth);
+
+    const container = getCachedContainer(getActiveGroupId());
+    const panelEl = container
+      ? container.querySelector(`[data-panel-id="${panelId}"]`)
+      : document.querySelector(`[data-panel-id="${panelId}"]`);
+    if (panelEl) {
+      panelEl.style.width = newWidth + 'px';
+      panelEl.scrollIntoView({ behavior: 'smooth', inline: 'nearest' });
+    }
+
+    if (activeTerminals.has(panelId)) {
+      const { fitAddon } = activeTerminals.get(panelId);
+      if (fitAddon) {
+        try { fitAddon.fit(); } catch (e) {}
+      }
+    }
+    if (activeEditors.has(panelId)) {
+      const { editor } = activeEditors.get(panelId);
+      if (editor) {
+        try { editor.layout(); } catch (e) {}
+      }
+    }
+
+    saveState();
   });
 
   return handle;

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -342,7 +342,12 @@ body {
   flex-shrink: 0;
   min-width: 300px;
   contain: layout style paint;
+  transition: width 0.2s ease-out;
 }
+
+body.resizing .panel { transition: none; }
+body.resizing webview, body.resizing iframe { pointer-events: none !important; }
+body.resizing, body.resizing * { cursor: col-resize !important; }
 
 .panel-focused {
   box-shadow: 0 0 12px 2px rgba(83, 52, 131, 0.35);
@@ -484,19 +489,32 @@ body {
 /* ── Resize handle ───────────────────────────────── */
 
 .resize-handle {
-  width: 6px;
-  min-width: 6px;
+  width: 12px;
+  min-width: 12px;
   cursor: col-resize;
   background: transparent;
   align-self: stretch;
   border-radius: 3px;
-  margin: 8px 3px;
-  transition: background 0.15s;
+  margin: 8px 0;
   flex-shrink: 0;
+  position: relative;
 }
 
-.resize-handle:hover,
-.resize-handle.active { background: #533483; }
+.resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 4px;
+  transform: translateX(-50%);
+  background: transparent;
+  border-radius: 2px;
+  transition: background 0.15s;
+}
+
+.resize-handle:hover::after,
+.resize-handle.active::after { background: #533483; }
 
 /* ── Add panel controls ──────────────────────────── */
 


### PR DESCRIPTION
… double-click expand

- Widen resize handle hit area from 6px to 12px with 4px visual indicator
- Add body.resizing class to block webview pointer events during drag
- Throttle DOM updates with requestAnimationFrame during resize
- Add double-click on handle to expand panel by 2x
- Add smooth width transition for panels, disabled during drag