### PR TITLE
fix: LSP diagnostic squiggly lines not rendering

### DIFF
--- a/renderer/index.html
+++ b/renderer/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self' 'unsafe-inline' blob:; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; frame-src *;">
+    content="default-src 'self' 'unsafe-inline' blob:; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src *;">
   <title>Worklayer</title>
   <link rel="stylesheet" href="../node_modules/@xterm/xterm/css/xterm.css">
   <link rel="stylesheet" href="styles.css">

--- a/renderer/lsp/lsp-bridge.js
+++ b/renderer/lsp/lsp-bridge.js
@@ -287,6 +287,15 @@ function flushDidChange(serverId, filePath) {
   pending.flush();
 }
 
+function lspDidSave(serverId, filePath, content) {
+  flushDidChange(serverId, filePath);
+  const uri = filePathToUri(filePath);
+  window.electronAPI.lspSendNotification(serverId, 'textDocument/didSave', {
+    textDocument: { uri },
+    text: content,
+  });
+}
+
 function lspDidClose(serverId, filePath) {
   const key = `${serverId}:${filePath}`;
   const pending = didChangePending.get(key);

--- a/renderer/panels/file-panel.js
+++ b/renderer/panels/file-panel.js
@@ -170,6 +170,9 @@ function renderFilePanel(panel, container) {
     } else {
       setDirty(false);
       updateGitDecorations();
+      for (const sid of panelLspServerIds) {
+        lspDidSave(sid, currentFilePath, content);
+      }
     }
   }
 
@@ -233,6 +236,7 @@ function renderFilePanel(panel, container) {
       return;
     }
 
+    const previousFilePath = currentFilePath;
     currentFilePath = filePath;
     panel.openFile = filePath;
     saveState();
@@ -298,9 +302,9 @@ function renderFilePanel(panel, container) {
       requestAnimationFrame(() => currentEditor.layout());
     } else {
       // Close old file in LSP servers
-      if (currentFilePath && currentFilePath !== filePath) {
+      if (previousFilePath && previousFilePath !== filePath) {
         for (const sid of panelLspServerIds) {
-          lspDidClose(sid, currentFilePath);
+          lspDidClose(sid, previousFilePath);
         }
       }
 


### PR DESCRIPTION
- Fix didClose bug in file-panel.js: capture previousFilePath before overwriting currentFilePath so lspDidClose fires on file switch
- Add lspDidSave to lsp-bridge.js and call it from saveFile() so LSP servers re-analyze after save
- Add img-src 'self' data: to CSP so Monaco's SVG data URI squiggly underline backgrounds are not blocked

Closes #76 