### PR TITLE
feat: Add color-coded file tree indicators for git status and LSP errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -347,6 +347,43 @@ ipcMain.handle('git:diff', async (_, { filePath }) => {
   return { changes };
 });
 
+// Git status IPC handler (for file tree coloring)
+ipcMain.handle('git:status', async (_, { rootDir }) => {
+  const execOpts = { timeout: 5000, maxBuffer: 1024 * 1024 };
+  try {
+    const topLevel = await execFilePromise('git', ['rev-parse', '--show-toplevel'], { ...execOpts, cwd: rootDir });
+    if (topLevel.error) return { files: {} };
+    const gitRoot = topLevel.stdout.trim();
+
+    const status = await execFilePromise('git', ['status', '--porcelain'], { ...execOpts, cwd: gitRoot });
+    if (status.error) return { files: {} };
+
+    const files = {};
+    for (const line of status.stdout.split('\n')) {
+      if (!line || line.length < 4) continue;
+      const xy = line.substring(0, 2);
+      const filePart = line.substring(3);
+      // Handle renames: "R  old -> new"
+      const relPath = filePart.includes(' -> ') ? filePart.split(' -> ')[1] : filePart;
+      const absPath = path.join(gitRoot, relPath);
+
+      if (xy === '??') {
+        files[absPath] = 'new';
+      } else if (xy === 'A ' || xy === 'AM') {
+        files[absPath] = 'new';
+      } else if (xy === 'D ' || xy === ' D') {
+        files[absPath] = 'deleted';
+      } else {
+        // M , MM,  M, etc.
+        files[absPath] = 'modified';
+      }
+    }
+    return { files };
+  } catch (e) {
+    return { files: {} };
+  }
+});
+
 // Debug cookie inspection for persist:webpanels partition
 ipcMain.handle('debug:getCookies', async (_, { url }) => {
   const ses = session.fromPartition('persist:webpanels');

--- a/preload.js
+++ b/preload.js
@@ -35,6 +35,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   readFile: (filePath) => ipcRenderer.invoke('fs:readFile', { filePath }),
   writeFile: (filePath, content) => ipcRenderer.invoke('fs:writeFile', { filePath, content }),
   gitDiff: (filePath) => ipcRenderer.invoke('git:diff', { filePath }),
+  gitStatus: (rootDir) => ipcRenderer.invoke('git:status', { rootDir }),
 
   // LSP
   lspGetRegistry: () => ipcRenderer.invoke('lsp:getRegistry'),

--- a/renderer/lsp/lsp-bridge.js
+++ b/renderer/lsp/lsp-bridge.js
@@ -8,6 +8,26 @@ const didChangePending = new Map();
 
 const DIDCHANGE_DEBOUNCE_MS = 300;
 
+// Global file error tracking for tree coloring
+// Map<filePath, errorCount>
+const fileErrorMap = new Map();
+const diagnosticChangeCallbacks = new Set();
+
+function onDiagnosticChange(callback) {
+  diagnosticChangeCallbacks.add(callback);
+  return () => diagnosticChangeCallbacks.delete(callback);
+}
+
+function getFileErrorMap() {
+  return fileErrorMap;
+}
+
+function notifyDiagnosticChange() {
+  for (const cb of diagnosticChangeCallbacks) {
+    try { cb(); } catch (_) {}
+  }
+}
+
 // --- LSP <-> Monaco coordinate mapping ---
 // LSP: 0-based line/char, Monaco: 1-based line/column
 
@@ -85,6 +105,15 @@ function handleDiagnostics(serverKey, params) {
 
   console.log(`[LSP-bridge] setting ${markers.length} markers for ${serverKey} on ${filePath}`);
   monaco.editor.setModelMarkers(model, serverKey, markers);
+
+  // Update global file error map
+  const errorCount = markers.filter(m => m.severity === 8).length;
+  if (errorCount > 0) {
+    fileErrorMap.set(filePath, errorCount);
+  } else {
+    fileErrorMap.delete(filePath);
+  }
+  notifyDiagnosticChange();
 }
 
 // --- Provider registration ---
@@ -342,6 +371,16 @@ function disconnectLspServer(serverId, serverKey) {
     for (const model of monaco.editor.getModels()) {
       monaco.editor.setModelMarkers(model, serverKey, []);
     }
+    // Recompute file error map from remaining markers
+    fileErrorMap.clear();
+    for (const model of monaco.editor.getModels()) {
+      const allMarkers = monaco.editor.getModelMarkers({ resource: model.uri });
+      const errors = allMarkers.filter(m => m.severity === 8).length;
+      if (errors > 0) {
+        fileErrorMap.set(model.uri.path, errors);
+      }
+    }
+    notifyDiagnosticChange();
   }
 }
 

--- a/renderer/panels/file-panel.js
+++ b/renderer/panels/file-panel.js
@@ -154,6 +154,7 @@ function renderFilePanel(panel, container) {
   let docVersion = 0;
   let gitDecorationCollection = null;
   const panelLspServerIds = []; // track server IDs started for this panel
+  let cleanupDiagListener = null;
 
   function setDirty(dirty) {
     isDirty = dirty;
@@ -170,6 +171,7 @@ function renderFilePanel(panel, container) {
     } else {
       setDirty(false);
       updateGitDecorations();
+      applyTreeColors();
       for (const sid of panelLspServerIds) {
         lspDidSave(sid, currentFilePath, content);
       }
@@ -294,6 +296,7 @@ function renderFilePanel(panel, container) {
               lspDidClose(sid, currentFilePath);
             }
           }
+          if (cleanupDiagListener) cleanupDiagListener();
           currentEditor.dispose();
           activeEditors.delete(panel.id);
         },
@@ -358,6 +361,7 @@ function renderFilePanel(panel, container) {
       parentEl.appendChild(item);
 
       if (entry.isDirectory) {
+        item.dataset.path = dirPath + '/' + entry.name;
         const children = document.createElement('div');
         children.className = 'tree-children';
         children.hidden = true;
@@ -372,10 +376,12 @@ function renderFilePanel(panel, container) {
           if (!loaded) {
             loaded = true;
             await loadTreeEntries(dirPath + '/' + entry.name, children, depth + 1);
+            applyTreeColors();
           }
         });
       } else {
         const fullPath = dirPath + '/' + entry.name;
+        item.dataset.path = fullPath;
         item.addEventListener('click', (e) => {
           e.stopPropagation();
           if (activeTreeItem) activeTreeItem.classList.remove('active');
@@ -387,14 +393,114 @@ function renderFilePanel(panel, container) {
     });
   }
 
+  // --- Tree coloring for git status & diagnostics ---
+
+  async function applyTreeColors() {
+    if (!panel.rootDir) return;
+
+    const gitResult = await window.electronAPI.gitStatus(panel.rootDir);
+    const gitFiles = gitResult.files || {};
+    const errorMap = getFileErrorMap();
+
+    const allItems = treeContainer.querySelectorAll('.tree-item');
+    for (const item of allItems) {
+      item.classList.remove('git-modified', 'git-new', 'has-errors');
+    }
+
+    // Color file items
+    for (const item of allItems) {
+      const p = item.dataset.path;
+      if (!p) continue;
+
+      if (item.classList.contains('tree-file')) {
+        const hasError = errorMap.has(p);
+        const gitStatus = gitFiles[p];
+
+        if (hasError) {
+          item.classList.add('has-errors');
+        } else if (gitStatus === 'modified') {
+          item.classList.add('git-modified');
+        } else if (gitStatus === 'new') {
+          item.classList.add('git-new');
+        }
+      }
+    }
+
+    // Propagate to parent directories
+    // For each colored file, walk up through tree-children -> tree-directory
+    for (const item of allItems) {
+      if (!item.classList.contains('tree-file')) continue;
+      if (!item.classList.contains('git-modified') && !item.classList.contains('git-new') && !item.classList.contains('has-errors')) continue;
+
+      let el = item.parentElement;
+      while (el && el !== treeContainer) {
+        if (el.classList.contains('tree-children')) {
+          // The directory item is the previous sibling
+          const dirItem = el.previousElementSibling;
+          if (dirItem && dirItem.classList.contains('tree-directory')) {
+            // Apply highest priority: has-errors > git-modified > git-new
+            if (item.classList.contains('has-errors')) {
+              dirItem.classList.remove('git-modified', 'git-new');
+              dirItem.classList.add('has-errors');
+            } else if (item.classList.contains('git-modified') && !dirItem.classList.contains('has-errors')) {
+              dirItem.classList.remove('git-new');
+              dirItem.classList.add('git-modified');
+            } else if (item.classList.contains('git-new') && !dirItem.classList.contains('has-errors') && !dirItem.classList.contains('git-modified')) {
+              dirItem.classList.add('git-new');
+            }
+          }
+        }
+        el = el.parentElement;
+      }
+    }
+
+    // Color directories whose children haven't been loaded yet
+    for (const [absPath, status] of Object.entries(gitFiles)) {
+      if (status === 'deleted') continue;
+      // Find directory items that are ancestors of this path
+      const dirItems = treeContainer.querySelectorAll('.tree-item.tree-directory');
+      for (const dirItem of dirItems) {
+        const dirPath = dirItem.dataset.path;
+        if (!dirPath) continue;
+        if (absPath.startsWith(dirPath + '/')) {
+          if (status === 'modified' && !dirItem.classList.contains('has-errors')) {
+            dirItem.classList.remove('git-new');
+            dirItem.classList.add('git-modified');
+          } else if (status === 'new' && !dirItem.classList.contains('has-errors') && !dirItem.classList.contains('git-modified')) {
+            dirItem.classList.add('git-new');
+          }
+        }
+      }
+    }
+
+    // Also propagate errors for unloaded directories
+    for (const [filePath] of errorMap) {
+      const dirItems = treeContainer.querySelectorAll('.tree-item.tree-directory');
+      for (const dirItem of dirItems) {
+        const dirPath = dirItem.dataset.path;
+        if (!dirPath) continue;
+        if (filePath.startsWith(dirPath + '/')) {
+          dirItem.classList.remove('git-modified', 'git-new');
+          dirItem.classList.add('has-errors');
+        }
+      }
+    }
+  }
+
+  let applyTreeColorsTimer = null;
+  function scheduleApplyTreeColors() {
+    clearTimeout(applyTreeColorsTimer);
+    applyTreeColorsTimer = setTimeout(applyTreeColors, 200);
+  }
+
   if (panel.rootDir) {
-    loadTreeEntries(panel.rootDir, treeContainer, 0);
+    loadTreeEntries(panel.rootDir, treeContainer, 0).then(() => applyTreeColors());
   }
 
   refreshBtn.addEventListener('click', () => {
     treeContainer.innerHTML = '';
     if (panel.rootDir) {
-      loadTreeEntries(panel.rootDir, treeContainer, 0);
+      loadTreeEntries(panel.rootDir, treeContainer, 0).then(() => applyTreeColors());
     }
   });
 
@@ -556,6 +662,9 @@ function renderFilePanel(panel, container) {
   }
 
   autoStartLsp();
+
+  // Register diagnostic change listener for tree coloring
+  cleanupDiagListener = onDiagnosticChange(scheduleApplyTreeColors);
 
   // Internal sidebar resize
   let sidebarWidth = 220;

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1309,6 +1309,15 @@ webview {
   background: #50fa7b;
 }
 
+/* File tree color indicators */
+.tree-item.git-modified .tree-name { color: #e5c07b; }
+.tree-item.git-new .tree-name { color: #50fa7b; }
+.tree-item.has-errors .tree-name { color: #ff5555; }
+
+.tree-item.active.git-modified .tree-name { color: #f0d88a; }
+.tree-item.active.git-new .tree-name { color: #70ffaa; }
+.tree-item.active.has-errors .tree-name { color: #ff7777; }
+
 /* Git gutter indicators */
 .git-gutter-added {
   background: #50fa7b;


### PR DESCRIPTION
Color file tree items to visually indicate git modified (yellow), new/untracked (green), and LSP error (red) files, with parent directory propagation. Mirrors VS Code file explorer behavior.

Closes #78 