### PR TITLE
feat: Show popup notification when panel limit is reached

### DIFF
--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -285,7 +285,10 @@ async function addPanel(type) {
   const maxLimits = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
   const maxForType = maxLimits[type];
   const profileCount = profile.groups.flatMap(g => g.panels).filter(p => p.type === type).length;
-  if (maxForType && profileCount >= maxForType) return;
+  if (maxForType && profileCount >= maxForType) {
+    showPanelLimitNotification(type);
+    return;
+  }
 
   let extraProps = {};
   if (type === 'web') {
@@ -337,7 +340,10 @@ function addWebPanelAt(url, insertIndex) {
   const profile = getActiveProfile();
   if (!profile) return null;
   const profileWebCount = profile.groups.flatMap(g => g.panels).filter(p => p.type === 'web').length;
-  if (profileWebCount >= MAX_WEB_PANELS) return null;
+  if (profileWebCount >= MAX_WEB_PANELS) {
+    showPanelLimitNotification('web');
+    return null;
+  }
 
   const panel = {
     id: generateId(),

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -35,6 +35,7 @@
   <script src="lsp/lsp-bridge.js"></script>
   <script src="modals/lsp-settings-modal.js"></script>
   <script src="modals/auth-modal.js"></script>
+  <script src="modals/panel-limit-modal.js"></script>
   <script src="panels/file-panel.js"></script>
   <script src="panels/panel-drag.js"></script>
 </body>

--- a/renderer/modals/panel-limit-modal.js
+++ b/renderer/modals/panel-limit-modal.js
@@ -1,0 +1,59 @@
+// panel-limit-modal.js - Notification popup when panel limit is reached
+
+function showPanelLimitNotification(type) {
+  if (document.querySelector('.panel-limit-overlay')) return;
+
+  const limits = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
+  const limit = limits[type] || '?';
+
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay panel-limit-overlay';
+
+  const container = document.createElement('div');
+  container.className = 'modal-container';
+  container.style.width = '380px';
+
+  const header = document.createElement('div');
+  header.className = 'modal-header';
+  header.textContent = 'Panel Limit Reached';
+  container.appendChild(header);
+
+  const message = document.createElement('div');
+  message.style.fontSize = '13px';
+  message.style.color = '#bbb';
+  message.style.lineHeight = '1.5';
+  message.textContent = `You\u2019ve reached the maximum of ${limit} ${type} panels. Close an existing ${type} panel to add a new one.`;
+  container.appendChild(message);
+
+  const footer = document.createElement('div');
+  footer.className = 'modal-footer';
+
+  const okBtn = document.createElement('button');
+  okBtn.className = 'modal-btn modal-btn-create';
+  okBtn.textContent = 'OK';
+
+  footer.appendChild(okBtn);
+  container.appendChild(footer);
+  overlay.appendChild(container);
+
+  function dismiss() {
+    overlay.remove();
+    document.removeEventListener('keydown', onKey);
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape' || e.key === 'Enter') {
+      e.preventDefault();
+      dismiss();
+    }
+  }
+
+  okBtn.addEventListener('click', dismiss);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) dismiss();
+  });
+  document.addEventListener('keydown', onKey);
+
+  document.body.appendChild(overlay);
+  okBtn.focus();
+}


### PR DESCRIPTION
Instead of silently ignoring the action, display an informational modal when the user tries to add a panel beyond the maximum allowed (20 terminal, 20 web, 10 file).