### PR TITLE
feat: Add file search to file tree sidebar with mode toggle and filters

### DIFF
--- a/main.js
+++ b/main.js
@@ -214,6 +214,43 @@ ipcMain.handle('fs:readDirectory', (_, { dirPath }) => {
   }
 });
 
+ipcMain.handle('fs:scanDirectory', (_, { rootDir, maxFiles = 50000 }) => {
+  try {
+    const SKIP_DIRS = new Set(['node_modules', '.git', '__pycache__', '.venv', 'venv', 'dist', 'build']);
+    const files = [];
+    let truncated = false;
+
+    function walk(dir) {
+      if (truncated) return;
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch (e) {
+        return;
+      }
+      for (const entry of entries) {
+        if (entry.name.startsWith('.')) continue;
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (SKIP_DIRS.has(entry.name)) continue;
+          walk(fullPath);
+        } else {
+          files.push(fullPath);
+          if (files.length >= maxFiles) {
+            truncated = true;
+            return;
+          }
+        }
+      }
+    }
+
+    walk(rootDir);
+    return { files, truncated };
+  } catch (e) {
+    return { error: e.message };
+  }
+});
+
 ipcMain.handle('fs:readFile', (_, { filePath }) => {
   try {
     const content = fs.readFileSync(filePath, 'utf-8');

--- a/preload.js
+++ b/preload.js
@@ -32,6 +32,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   openDirectory: () => ipcRenderer.invoke('dialog:openDirectory'),
   readDirectory: (dirPath) => ipcRenderer.invoke('fs:readDirectory', { dirPath }),
+  scanDirectory: (rootDir, maxFiles) => ipcRenderer.invoke('fs:scanDirectory', { rootDir, maxFiles }),
   readFile: (filePath) => ipcRenderer.invoke('fs:readFile', { filePath }),
   writeFile: (filePath, content) => ipcRenderer.invoke('fs:writeFile', { filePath, content }),
   gitDiff: (filePath) => ipcRenderer.invoke('git:diff', { filePath }),

--- a/renderer/panels/file-panel.js
+++ b/renderer/panels/file-panel.js
@@ -92,9 +92,58 @@ function renderFilePanel(panel, container) {
   treeHeader.appendChild(refreshBtn);
   sidebar.appendChild(treeHeader);
 
+  // Search section
+  const searchSection = document.createElement('div');
+  searchSection.className = 'file-search-section';
+
+  const searchRow = document.createElement('div');
+  searchRow.className = 'file-search-row';
+
+  const searchInput = document.createElement('input');
+  searchInput.className = 'file-search-input';
+  searchInput.type = 'text';
+  searchInput.placeholder = 'Search files...';
+
+  const searchModeBtn = document.createElement('button');
+  searchModeBtn.className = 'file-search-mode-btn';
+  searchModeBtn.textContent = 'aa';
+  searchModeBtn.title = 'Search mode: case-insensitive';
+
+  searchRow.appendChild(searchInput);
+  searchRow.appendChild(searchModeBtn);
+
+  const filterRow = document.createElement('div');
+  filterRow.className = 'file-search-filter-row';
+
+  const includeInput = document.createElement('input');
+  includeInput.className = 'file-search-include';
+  includeInput.type = 'text';
+  includeInput.placeholder = 'Include *.js,*.ts';
+
+  const excludeInput = document.createElement('input');
+  excludeInput.className = 'file-search-exclude';
+  excludeInput.type = 'text';
+  excludeInput.placeholder = 'Exclude *.test.js';
+
+  filterRow.appendChild(includeInput);
+  filterRow.appendChild(excludeInput);
+
+  const searchInfo = document.createElement('div');
+  searchInfo.className = 'file-search-info';
+
+  searchSection.appendChild(searchRow);
+  searchSection.appendChild(filterRow);
+  searchSection.appendChild(searchInfo);
+  sidebar.appendChild(searchSection);
+
   const treeContainer = document.createElement('div');
   treeContainer.className = 'file-tree-entries';
   sidebar.appendChild(treeContainer);
+
+  const searchResults = document.createElement('div');
+  searchResults.className = 'file-search-results';
+  searchResults.hidden = true;
+  sidebar.appendChild(searchResults);
 
   // Internal resize handle
   const resizeHandle = document.createElement('div');
@@ -628,7 +677,194 @@ function renderFilePanel(panel, container) {
     loadTreeEntries(panel.rootDir, treeContainer, 0).then(() => applyTreeColors());
   }
 
+  // --- File search ---
+
+  let cachedFileList = null;
+  let isFileListLoading = false;
+  let searchDebounceTimer = null;
+  let currentSearchMode = 'loose'; // 'loose' | 'strict' | 'regex'
+  let isSearchActive = false;
+
+  function updateModeButton() {
+    searchModeBtn.classList.remove('mode-strict', 'mode-regex');
+    if (currentSearchMode === 'loose') {
+      searchModeBtn.textContent = 'aa';
+      searchModeBtn.title = 'Search mode: case-insensitive';
+    } else if (currentSearchMode === 'strict') {
+      searchModeBtn.textContent = 'Aa';
+      searchModeBtn.title = 'Search mode: case-sensitive';
+      searchModeBtn.classList.add('mode-strict');
+    } else {
+      searchModeBtn.textContent = '.*';
+      searchModeBtn.title = 'Search mode: regex';
+      searchModeBtn.classList.add('mode-regex');
+    }
+  }
+
+  searchModeBtn.addEventListener('click', () => {
+    if (currentSearchMode === 'loose') currentSearchMode = 'strict';
+    else if (currentSearchMode === 'strict') currentSearchMode = 'regex';
+    else currentSearchMode = 'loose';
+    updateModeButton();
+    scheduleSearch();
+  });
+
+  async function ensureFileList() {
+    if (cachedFileList) return cachedFileList;
+    if (isFileListLoading) return null;
+    isFileListLoading = true;
+    searchInfo.textContent = 'Scanning...';
+    const result = await window.electronAPI.scanDirectory(panel.rootDir);
+    isFileListLoading = false;
+    if (result.error) {
+      searchInfo.textContent = 'Scan failed';
+      return null;
+    }
+    cachedFileList = result.files;
+    if (result.truncated) {
+      searchInfo.textContent = `${result.files.length}+ files (truncated)`;
+    }
+    return cachedFileList;
+  }
+
+  function parseGlobPatterns(input) {
+    if (!input.trim()) return [];
+    return input.split(',').map(p => p.trim()).filter(Boolean).map(pattern => {
+      const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+                             .replace(/\*/g, '.*')
+                             .replace(/\?/g, '.');
+      return new RegExp('^' + escaped + '$', 'i');
+    });
+  }
+
+  function showSearchResults(results) {
+    isSearchActive = true;
+    treeContainer.hidden = true;
+    searchResults.hidden = false;
+    searchResults.innerHTML = '';
+
+    const MAX_DISPLAY = 500;
+    const displayResults = results.slice(0, MAX_DISPLAY);
+
+    searchInfo.textContent = results.length > MAX_DISPLAY
+      ? `${results.length} matches (showing ${MAX_DISPLAY})`
+      : `${results.length} match${results.length !== 1 ? 'es' : ''}`;
+
+    displayResults.forEach(fullPath => {
+      const item = document.createElement('div');
+      item.className = 'tree-item tree-file file-search-result-item';
+
+      const relPath = fullPath.substring(panel.rootDir.length + 1);
+      const fileName = relPath.split('/').pop();
+      const dirPath = relPath.substring(0, relPath.length - fileName.length);
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'tree-name';
+      nameSpan.textContent = fileName;
+
+      const pathSpan = document.createElement('span');
+      pathSpan.className = 'file-search-result-path';
+      pathSpan.textContent = dirPath;
+
+      item.appendChild(nameSpan);
+      item.appendChild(pathSpan);
+      item.title = fullPath;
+
+      item.addEventListener('click', () => {
+        if (activeTreeItem) activeTreeItem.classList.remove('active');
+        item.classList.add('active');
+        activeTreeItem = item;
+        openFile(fullPath);
+      });
+
+      searchResults.appendChild(item);
+    });
+  }
+
+  function exitSearch() {
+    isSearchActive = false;
+    treeContainer.hidden = false;
+    searchResults.hidden = true;
+    searchResults.innerHTML = '';
+    searchInfo.textContent = '';
+  }
+
+  async function executeSearch() {
+    const query = searchInput.value.trim();
+    if (!query && !includeInput.value.trim() && !excludeInput.value.trim()) {
+      exitSearch();
+      return;
+    }
+
+    if (!panel.rootDir) return;
+
+    const files = await ensureFileList();
+    if (!files) return;
+
+    // Build matcher based on mode
+    let matcher;
+    if (!query) {
+      matcher = () => true;
+    } else if (currentSearchMode === 'strict') {
+      matcher = (relPath) => relPath.includes(query);
+    } else if (currentSearchMode === 'loose') {
+      const lowerQ = query.toLowerCase();
+      matcher = (relPath) => relPath.toLowerCase().includes(lowerQ);
+    } else {
+      try {
+        const re = new RegExp(query);
+        matcher = (relPath) => re.test(relPath);
+      } catch (e) {
+        searchInfo.textContent = 'Invalid regex';
+        return;
+      }
+    }
+
+    const includePatterns = parseGlobPatterns(includeInput.value);
+    const excludePatterns = parseGlobPatterns(excludeInput.value);
+
+    const results = files.filter(fullPath => {
+      const relPath = fullPath.substring(panel.rootDir.length + 1);
+      const fileName = relPath.split('/').pop();
+
+      if (includePatterns.length > 0) {
+        if (!includePatterns.some(re => re.test(fileName))) return false;
+      }
+      if (excludePatterns.length > 0) {
+        if (excludePatterns.some(re => re.test(fileName))) return false;
+      }
+
+      return matcher(relPath);
+    });
+
+    showSearchResults(results);
+  }
+
+  function scheduleSearch() {
+    clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(executeSearch, 200);
+  }
+
+  searchInput.addEventListener('input', scheduleSearch);
+  includeInput.addEventListener('input', scheduleSearch);
+  excludeInput.addEventListener('input', scheduleSearch);
+
+  searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      searchInput.value = '';
+      includeInput.value = '';
+      excludeInput.value = '';
+      exitSearch();
+    }
+  });
+
   refreshBtn.addEventListener('click', () => {
+    searchInput.value = '';
+    includeInput.value = '';
+    excludeInput.value = '';
+    cachedFileList = null;
+    exitSearch();
+
     treeContainer.innerHTML = '';
     if (panel.rootDir) {
       loadTreeEntries(panel.rootDir, treeContainer, 0).then(() => applyTreeColors());

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -756,6 +756,138 @@ webview {
   color: #ccc;
 }
 
+/* ── File search section ─────────────────────────── */
+
+.file-search-section {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 6px;
+  background: #1e1e30;
+  border-bottom: 1px solid #2a2a3e;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.file-search-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.file-search-input {
+  flex: 1;
+  background: #12121e;
+  border: 1px solid #334;
+  color: #ccc;
+  padding: 3px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  outline: none;
+  min-width: 0;
+  user-select: text;
+}
+
+.file-search-input:focus {
+  border-color: #533483;
+  color: #e0e0e0;
+}
+
+.file-search-mode-btn {
+  background: none;
+  border: 1px solid #334;
+  color: #889;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  transition: all 0.12s;
+  white-space: nowrap;
+  flex-shrink: 0;
+  min-width: 24px;
+  text-align: center;
+}
+
+.file-search-mode-btn:hover {
+  border-color: #533483;
+  color: #ccc;
+  background: #2a2a4e;
+}
+
+.file-search-mode-btn.mode-strict { color: #e5c07b; border-color: #665830; }
+.file-search-mode-btn.mode-regex  { color: #8be9fd; border-color: #3a6070; }
+
+.file-search-filter-row {
+  display: flex;
+  gap: 4px;
+}
+
+.file-search-include,
+.file-search-exclude {
+  flex: 1;
+  background: #12121e;
+  border: 1px solid #334;
+  color: #aaa;
+  padding: 2px 5px;
+  border-radius: 3px;
+  font-size: 10px;
+  outline: none;
+  min-width: 0;
+  user-select: text;
+}
+
+.file-search-include::placeholder,
+.file-search-exclude::placeholder {
+  color: #445;
+  font-size: 10px;
+}
+
+.file-search-include:focus,
+.file-search-exclude:focus {
+  border-color: #533483;
+  color: #ccc;
+}
+
+.file-search-info {
+  font-size: 10px;
+  color: #667;
+  padding: 0 2px;
+  min-height: 14px;
+}
+
+/* ── File search results ─────────────────────────── */
+
+.file-search-results {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 4px 0;
+}
+
+.file-search-results::-webkit-scrollbar { width: 4px; }
+.file-search-results::-webkit-scrollbar-track { background: transparent; }
+.file-search-results::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }
+
+.file-search-result-item {
+  padding: 3px 8px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+}
+
+.file-search-result-path {
+  font-size: 9px;
+  color: #556;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.file-search-result-item:hover .file-search-result-path {
+  color: #778;
+}
+
 .file-tree-entries {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
Adds search-as-you-type in the file browser sidebar with 200ms debounce. Three search modes (case-insensitive, case-sensitive, regex) cycle via a toggle button. Inclusion/exclusion glob filters narrow results by filename. A new recursive fs:scanDirectory IPC handler scans the full directory tree with caching. Results display as a flat list replacing the tree view, restoring on clear or Escape.

Closes #80 