### PR TITLE
fix: Use webview.src for initial load to avoid DOM attachment error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# Worklayer Project Instructions
+
+## Critical: WebView Initial Load in web-panel.js
+
+**DO NOT change the initial webview load in `renderer/panels/web-panel.js` from `webview.src` to `webview.loadURL()`.**
+
+This has been broken and fixed 4 times (commits `69c859d` → `1e4f8b0` → `ba0155a` → current fix). The root cause:
+
+- `renderWebPanel()` creates the webview and appends it to a `content` div, but that div's parent chain (`panel el` → `wrapper`) is not appended to the live DOM until later in `panel-strip.js` (`strip.appendChild(wrapper)`).
+- `webview.loadURL()` requires the webview to be attached to the live DOM **and** `dom-ready` to have fired. Calling it before that throws: `"The WebView must be attached to the DOM and the dom-ready event emitted before this method can be called."`
+- `webview.src = url` works before DOM attachment — Electron queues the load until the webview is ready.
+
+### Rules
+
+1. **Initial load** (in `renderWebPanel`): MUST use `webview.src = url`. Never use `loadURL()` or `loadURLWithRetry()` here.
+2. **User-initiated navigation** (in `navigate()` and crash retry): `loadURL()` / `loadURLWithRetry()` is fine — by that point the webview is attached and `dom-ready` has fired.
+3. **Error handling for initial load**: Rely on the `did-fail-load` event listener, which already catches failures and calls `showErrorPage()`.

--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -148,14 +148,10 @@ function renderWebPanel(panel, container) {
   webview.setAttribute('partition', 'persist:webpanels');
   const initialUrl = panel.url || 'about:blank';
   container.appendChild(webview);
-  if (initialUrl === 'about:blank') {
-    webview.src = 'about:blank';
-  } else {
-    loadURLWithRetry(webview, initialUrl, 2, (err) => {
-      console.log(`[WebPanel] loadURL failed (init) panel=${panel.id} url=${initialUrl} error=${err.message}`);
-      showErrorPage(initialUrl, err.message, -2);
-    });
-  }
+  // Use src attribute for initial load — loadURL() requires the webview to be
+  // attached to the live DOM with dom-ready fired, but at this point the
+  // wrapper hasn't been appended to the panel strip yet.
+  webview.src = initialUrl;
 
   console.log(`[WebPanel] Created webview panel=${panel.id} url=${panel.url || 'about:blank'} partition=persist:webpanels`);
 


### PR DESCRIPTION
Replace loadURLWithRetry() with webview.src for the initial webview load. loadURL() requires the webview to be in the live DOM with dom-ready fired, but during renderWebPanel() the wrapper hasn't been appended to the panel strip yet. This bug has been introduced and fixed 4 times — added CLAUDE.md to document the constraint and prevent future regressions.