### PR TITLE
fix: Use Runtime.evaluate for MCP fill and type_text tools

### DIFF
--- a/main.js
+++ b/main.js
@@ -686,6 +686,7 @@ function startBrowserInterceptServer() {
               await wc.debugger.sendCommand('DOM.enable');
               await wc.debugger.sendCommand('Accessibility.enable');
               await wc.debugger.sendCommand('Network.enable');
+              await wc.debugger.sendCommand('Runtime.enable');
               debugLog('[CDP] Attached debugger to wcId:', wcId);
             } catch (e) {
               debugLog('[CDP] Attach error:', e.message);

--- a/mcp-server/cdp-client.js
+++ b/mcp-server/cdp-client.js
@@ -26,11 +26,24 @@ export class CdpClient {
     return new Promise((resolve, reject) => {
       const url = `http://127.0.0.1:${this.port}${path}?token=${this.token}`;
       http.get(url, (res) => {
+        const statusCode = res.statusCode;
         let data = '';
         res.on('data', (chunk) => data += chunk);
         res.on('end', () => {
-          try { resolve(JSON.parse(data)); }
-          catch { resolve(data); }
+          try {
+            const parsed = JSON.parse(data);
+            if (statusCode >= 400) {
+              reject(new Error(parsed.error || `HTTP ${statusCode}: ${data}`));
+            } else {
+              resolve(parsed);
+            }
+          } catch {
+            if (statusCode >= 400) {
+              reject(new Error(`HTTP ${statusCode}: ${data}`));
+            } else {
+              resolve(data);
+            }
+          }
         });
       }).on('error', reject);
     });
@@ -49,11 +62,24 @@ export class CdpClient {
           'Content-Length': Buffer.byteLength(payload),
         },
       }, (res) => {
+        const statusCode = res.statusCode;
         let data = '';
         res.on('data', (chunk) => data += chunk);
         res.on('end', () => {
-          try { resolve(JSON.parse(data)); }
-          catch { resolve(data); }
+          try {
+            const parsed = JSON.parse(data);
+            if (statusCode >= 400) {
+              reject(new Error(parsed.error || `HTTP ${statusCode}: ${data}`));
+            } else {
+              resolve(parsed);
+            }
+          } catch {
+            if (statusCode >= 400) {
+              reject(new Error(`HTTP ${statusCode}: ${data}`));
+            } else {
+              resolve(data);
+            }
+          }
         });
       });
       req.on('error', reject);

--- a/mcp-server/element.js
+++ b/mcp-server/element.js
@@ -30,6 +30,23 @@ export async function resolveUidToCoords(cdpClient, webContentsId, uid) {
   return { x, y };
 }
 
+export async function resolveUidToObjectId(cdpClient, webContentsId, uid) {
+  const map = getUidMap();
+  const backendNodeId = map.get(String(uid));
+  if (!backendNodeId) {
+    throw new Error(`UID ${uid} not found in snapshot. Take a new snapshot first.`);
+  }
+
+  const resolveResp = await cdpClient.sendCommand(webContentsId, 'DOM.resolveNode', {
+    backendNodeId,
+  });
+  if (resolveResp.error) throw new Error(resolveResp.error);
+  const objectId = resolveResp.result.object?.objectId;
+  if (!objectId) throw new Error('Could not resolve node to remote object');
+
+  return { objectId, backendNodeId };
+}
+
 export async function focusUid(cdpClient, webContentsId, uid) {
   const map = getUidMap();
   const backendNodeId = map.get(String(uid));

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -7,7 +7,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { CdpClient } from './cdp-client.js';
 import { takeSnapshot } from './snapshot.js';
-import { resolveUidToCoords, focusUid } from './element.js';
+import { resolveUidToCoords, focusUid, resolveUidToObjectId } from './element.js';
 
 const port = process.env.WORKLAYER_MCP_PORT;
 const token = process.env.WORKLAYER_MCP_TOKEN;
@@ -225,15 +225,54 @@ server.tool('type_text', 'Type text into the currently focused element', {
 }, async ({ text, submitKey }) => {
   return withMutex(async () => {
     const wcId = requirePanel();
-    await cdp.sendCommand(wcId, 'Input.insertText', { text });
+    // Use Runtime.evaluate to insert text via JS (CDP Input.insertText doesn't work in Electron webview debugger)
+    await cdp.sendCommand(wcId, 'Runtime.evaluate', {
+      expression: `(() => {
+        const text = ${JSON.stringify(text)};
+        const el = document.activeElement;
+        if (!el) return 'no-active-element';
+        if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
+          const nativeSetter = Object.getOwnPropertyDescriptor(
+            el.tagName === 'TEXTAREA'
+              ? window.HTMLTextAreaElement.prototype
+              : window.HTMLInputElement.prototype,
+            'value'
+          ).set;
+          const start = el.selectionStart || 0;
+          const end = el.selectionEnd || 0;
+          const current = el.value;
+          const newValue = current.substring(0, start) + text + current.substring(end);
+          nativeSetter.call(el, newValue);
+          el.selectionStart = el.selectionEnd = start + text.length;
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          return 'typed-native';
+        }
+        if (el.isContentEditable) {
+          document.execCommand('insertText', false, text);
+          return 'typed-contenteditable';
+        }
+        return 'unsupported-element';
+      })()`,
+      returnByValue: true,
+    });
+
     if (submitKey) {
-      await cdp.sendCommand(wcId, 'Input.dispatchKeyEvent', {
-        type: 'keyDown', key: submitKey, code: `Key${submitKey}`,
-        windowsVirtualKeyCode: submitKey === 'Enter' ? 13 : 0,
-      });
-      await cdp.sendCommand(wcId, 'Input.dispatchKeyEvent', {
-        type: 'keyUp', key: submitKey, code: `Key${submitKey}`,
-        windowsVirtualKeyCode: submitKey === 'Enter' ? 13 : 0,
+      await cdp.sendCommand(wcId, 'Runtime.evaluate', {
+        expression: `(() => {
+          const key = ${JSON.stringify(submitKey)};
+          const vkMap = { Enter: 13, Tab: 9, Escape: 27 };
+          const el = document.activeElement || document.body;
+          const opts = { key, code: key, keyCode: vkMap[key] || 0, which: vkMap[key] || 0, bubbles: true, cancelable: true };
+          const downEvent = new KeyboardEvent('keydown', opts);
+          const prevented = !el.dispatchEvent(downEvent);
+          if (!prevented && key === 'Enter') {
+            const form = el.closest('form');
+            if (form) { form.requestSubmit ? form.requestSubmit() : form.submit(); }
+          }
+          el.dispatchEvent(new KeyboardEvent('keyup', opts));
+          return 'key-dispatched';
+        })()`,
+        returnByValue: true,
       });
     }
     return { content: [{ type: 'text', text: `Typed "${text}"${submitKey ? ` + ${submitKey}` : ''}` }] };
@@ -247,21 +286,44 @@ server.tool('fill', 'Focus element by UID, clear it, and fill with value', {
   return withMutex(async () => {
     const wcId = requirePanel();
     await focusUid(cdp, wcId, uid);
-    // Select all then delete to clear
-    await cdp.sendCommand(wcId, 'Input.dispatchKeyEvent', {
-      type: 'keyDown', key: 'a', code: 'KeyA', modifiers: process.platform === 'darwin' ? 4 : 2, // meta or ctrl
+    const { objectId } = await resolveUidToObjectId(cdp, wcId, uid);
+    // Use Runtime.callFunctionOn to clear and fill (CDP Input commands don't work in Electron webview debugger)
+    const fillResp = await cdp.sendCommand(wcId, 'Runtime.callFunctionOn', {
+      objectId,
+      functionDeclaration: `function(newValue) {
+        if (this.tagName === 'SELECT') {
+          this.value = newValue;
+          this.dispatchEvent(new Event('input', { bubbles: true }));
+          this.dispatchEvent(new Event('change', { bubbles: true }));
+          return 'filled-select';
+        }
+        if (this.tagName === 'INPUT' || this.tagName === 'TEXTAREA') {
+          const nativeSetter = Object.getOwnPropertyDescriptor(
+            this.tagName === 'TEXTAREA'
+              ? window.HTMLTextAreaElement.prototype
+              : window.HTMLInputElement.prototype,
+            'value'
+          ).set;
+          nativeSetter.call(this, '');
+          this.dispatchEvent(new Event('input', { bubbles: true }));
+          nativeSetter.call(this, newValue);
+          this.dispatchEvent(new Event('input', { bubbles: true }));
+          this.dispatchEvent(new Event('change', { bubbles: true }));
+          return 'filled-native';
+        }
+        if (this.isContentEditable) {
+          this.focus();
+          document.execCommand('selectAll', false, null);
+          document.execCommand('delete', false, null);
+          document.execCommand('insertText', false, newValue);
+          return 'filled-contenteditable';
+        }
+        return 'unknown-element-type';
+      }`,
+      arguments: [{ value: value }],
+      returnByValue: true,
     });
-    await cdp.sendCommand(wcId, 'Input.dispatchKeyEvent', {
-      type: 'keyUp', key: 'a', code: 'KeyA', modifiers: process.platform === 'darwin' ? 4 : 2,
-    });
-    await cdp.sendCommand(wcId, 'Input.dispatchKeyEvent', {
-      type: 'keyDown', key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8,
-    });
-    await cdp.sendCommand(wcId, 'Input.dispatchKeyEvent', {
-      type: 'keyUp', key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8,
-    });
-    // Insert new text
-    await cdp.sendCommand(wcId, 'Input.insertText', { text: value });
+    if (fillResp.error) throw new Error(fillResp.error);
     return { content: [{ type: 'text', text: `Filled element [${uid}] with "${value}"` }] };
   });
 });


### PR DESCRIPTION
CDP Input.insertText and Input.dispatchKeyEvent don't work in Electron's webview debugger context (no OS-level focus). Replace with Runtime.evaluate/callFunctionOn using native value setters and document.execCommand for reliable text input. Also fix CDP client to properly reject on HTTP errors instead of silently swallowing them.