### PR TITLE
fix: Route MCP open_panel to caller's group instead of active group

### DIFF
--- a/main.js
+++ b/main.js
@@ -557,7 +557,8 @@ function setupBrowserHelperScripts() {
 URL="$1"
 if [ -z "$URL" ]; then exit 0; fi
 TERM_ID="$WORKLAYER_TERM_ID"
-curl -s -o /dev/null "http://127.0.0.1:${browserInterceptPort}/open?token=${browserInterceptToken}&termId=$TERM_ID&url=$(printf '%s' "$URL" | sed 's/ /%20/g; s/&/%26/g; s/?/%3F/g; s/#/%23/g')" 2>/dev/null
+GROUP_ID="$WORKLAYER_GROUP_ID"
+curl -s -o /dev/null "http://127.0.0.1:${browserInterceptPort}/open?token=${browserInterceptToken}&termId=$TERM_ID&groupId=$GROUP_ID&url=$(printf '%s' "$URL" | sed 's/ /%20/g; s/&/%26/g; s/?/%3F/g; s/#/%23/g')" 2>/dev/null
 `;
   fs.writeFileSync(worklayerBrowserPath, worklayerBrowserScript, { mode: 0o755 });
 
@@ -588,7 +589,8 @@ for arg in "$@"; do
 done
 if [ "$IS_URL" = "1" ] && [ -n "$TARGET" ]; then
   TERM_ID="$WORKLAYER_TERM_ID"
-  curl -s -o /dev/null "http://127.0.0.1:${browserInterceptPort}/open?token=${browserInterceptToken}&termId=$TERM_ID&url=$(printf '%s' "$TARGET" | sed 's/ /%20/g; s/&/%26/g; s/?/%3F/g; s/#/%23/g')" 2>/dev/null
+  GROUP_ID="$WORKLAYER_GROUP_ID"
+  curl -s -o /dev/null "http://127.0.0.1:${browserInterceptPort}/open?token=${browserInterceptToken}&termId=$TERM_ID&groupId=$GROUP_ID&url=$(printf '%s' "$TARGET" | sed 's/ /%20/g; s/&/%26/g; s/?/%3F/g; s/#/%23/g')" 2>/dev/null
 else
   /usr/bin/open $PASSTHROUGH_ARGS "$TARGET"
 fi
@@ -628,6 +630,7 @@ function startBrowserInterceptServer() {
         if (parsedUrl.pathname === '/open') {
           const termId = parsedUrl.searchParams.get('termId');
           const openUrl = parsedUrl.searchParams.get('url');
+          const groupId = parsedUrl.searchParams.get('groupId');
           if (!openUrl) {
             res.writeHead(400);
             res.end();
@@ -640,6 +643,7 @@ function startBrowserInterceptServer() {
             wins[0].webContents.send('terminal:browser-open', {
               termId: termId ? parseInt(termId, 10) : null,
               url: openUrl,
+              groupId: groupId || null,
             });
           }
           res.writeHead(200);
@@ -747,6 +751,7 @@ function startBrowserInterceptServer() {
                   requestId,
                   url: panelUrl,
                   termId: reqTermId !== undefined ? reqTermId : null,
+                  groupId: reqGroupId || null,
                 });
               } else {
                 pendingPanelCallbacks.delete(requestId);

--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -159,6 +159,20 @@ function getActiveGroup() {
   return profile.groups.find(g => g.id === profile.activeGroupId) || null;
 }
 
+function getGroupById(groupId) {
+  const profile = getActiveProfile();
+  if (!profile) return null;
+  return profile.groups.find(g => g.id === groupId) || null;
+}
+
+function resolveTargetGroup(targetGroupId) {
+  if (targetGroupId) {
+    const group = getGroupById(targetGroupId);
+    if (group) return group;
+  }
+  return getActiveGroup();
+}
+
 // ── Group operations ──────────────────────────────
 
 function addGroup() {
@@ -339,8 +353,8 @@ async function addPanel(type) {
   saveState();
 }
 
-function addWebPanelAt(url, insertIndex) {
-  const group = getActiveGroup();
+function addWebPanelAt(url, insertIndex, targetGroupId) {
+  const group = resolveTargetGroup(targetGroupId);
   if (!group) return null;
 
   const profile = getActiveProfile();
@@ -362,49 +376,73 @@ function addWebPanelAt(url, insertIndex) {
   group.panels.splice(idx, 0, panel);
 
   const activeGId = getActiveGroupId();
-  const cached = getCachedContainer(activeGId);
-  if (cached) {
-    const panelEls = cached.querySelectorAll('.panel');
-    const addControls = cached.querySelector('.add-panel-controls');
-    const panelEl = createPanelElement(panel);
-    const resizeHandle = createResizeHandle(panel.id);
+  const isActiveGroup = group.id === activeGId;
 
-    if (idx < panelEls.length) {
-      cached.insertBefore(panelEl, panelEls[idx]);
-      cached.insertBefore(resizeHandle, panelEls[idx]);
-    } else if (addControls) {
-      cached.insertBefore(panelEl, addControls);
-      cached.insertBefore(resizeHandle, addControls);
+  if (isActiveGroup) {
+    const cached = getCachedContainer(activeGId);
+    if (cached) {
+      const panelEls = cached.querySelectorAll('.panel');
+      const addControls = cached.querySelector('.add-panel-controls');
+      const panelEl = createPanelElement(panel);
+      const resizeHandle = createResizeHandle(panel.id);
+
+      if (idx < panelEls.length) {
+        cached.insertBefore(panelEl, panelEls[idx]);
+        cached.insertBefore(resizeHandle, panelEls[idx]);
+      } else if (addControls) {
+        cached.insertBefore(panelEl, addControls);
+        cached.insertBefore(resizeHandle, addControls);
+      } else {
+        removeCachedGroup(activeGId);
+        renderPanelStrip();
+        saveState();
+        return panel.id;
+      }
+      renderStatusBar();
     } else {
-      removeCachedGroup(activeGId);
       renderPanelStrip();
-      saveState();
-      return panel.id;
+    }
+  } else {
+    // Non-active group: insert into cached DOM if available
+    const cached = getCachedContainer(group.id);
+    if (cached) {
+      const panelEls = cached.querySelectorAll('.panel');
+      const addControls = cached.querySelector('.add-panel-controls');
+      const panelEl = createPanelElement(panel);
+      const resizeHandle = createResizeHandle(panel.id);
+
+      if (idx < panelEls.length) {
+        cached.insertBefore(panelEl, panelEls[idx]);
+        cached.insertBefore(resizeHandle, panelEls[idx]);
+      } else if (addControls) {
+        cached.insertBefore(panelEl, addControls);
+        cached.insertBefore(resizeHandle, addControls);
+      } else {
+        removeCachedGroup(group.id);
+      }
     }
     renderStatusBar();
-  } else {
-    renderPanelStrip();
   }
 
   saveState();
   return panel.id;
 }
 
-function addWebPanelAfter(sourcePanelId, url) {
-  const group = getActiveGroup();
+function addWebPanelAfter(sourcePanelId, url, targetGroupId) {
+  const group = resolveTargetGroup(targetGroupId);
   if (!group) return null;
   const sourceIndex = group.panels.findIndex(p => p.id === sourcePanelId);
   if (sourceIndex === -1) {
-    return addWebPanelAt(url, group.panels.length);
+    return addWebPanelAt(url, group.panels.length, targetGroupId);
   } else {
-    return addWebPanelAt(url, sourceIndex + 1);
+    return addWebPanelAt(url, sourceIndex + 1, targetGroupId);
   }
 }
 
-function addWebPanelAtEnd(url) {
-  const group = getActiveGroup();
+function addWebPanelAtEnd(url, targetGroupId) {
+  const group = resolveTargetGroup(targetGroupId);
   if (!group) return null;
-  return addWebPanelAt(url, group.panels.length);
+  return addWebPanelAt(url, group.panels.length, targetGroupId);
 }
 
 function removePanel(panelId) {

--- a/renderer/panels/browser-intercept.js
+++ b/renderer/panels/browser-intercept.js
@@ -1,7 +1,7 @@
 // browser-intercept.js — Opens URLs from terminal CLI tools as web panels
 
 (function () {
-  window.electronAPI.onTerminalBrowserOpen(({ termId, url }) => {
+  window.electronAPI.onTerminalBrowserOpen(({ termId, url, groupId }) => {
     if (!url) return;
 
     // Find the panelId that owns this termId
@@ -14,14 +14,14 @@
     }
 
     if (panelId) {
-      addWebPanelAfter(panelId, url);
+      addWebPanelAfter(panelId, url, groupId);
     } else {
-      addWebPanelAtEnd(url);
+      addWebPanelAtEnd(url, groupId);
     }
   });
 
   // MCP open_panel: create a web panel on request from main process
-  window.electronAPI.onPanelCreateRequest(({ requestId, url, termId }) => {
+  window.electronAPI.onPanelCreateRequest(({ requestId, url, termId, groupId }) => {
     try {
       let sourcePanelId = null;
       if (termId !== null && termId !== undefined) {
@@ -33,8 +33,8 @@
         }
       }
       const newPanelId = sourcePanelId
-        ? addWebPanelAfter(sourcePanelId, url)
-        : addWebPanelAtEnd(url);
+        ? addWebPanelAfter(sourcePanelId, url, groupId)
+        : addWebPanelAtEnd(url, groupId);
       window.electronAPI.panelCreateResponse(requestId, newPanelId, null);
     } catch (e) {
       window.electronAPI.panelCreateResponse(requestId, null, e.message);


### PR DESCRIPTION
When a terminal in Group A calls the MCP open_panel tool while the user is viewing Group B, the new web panel was incorrectly created in Group B. Now groupId is threaded through the full IPC chain (shell helpers → HTTP endpoints → renderer) and panel creation functions target the caller's group.

Closes #94 