### PR TITLE
fix: Update sidebar panel count pills on panel create/delete

### DIFF
--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -350,6 +350,7 @@ async function addPanel(type) {
     renderPanelStrip();
   }
 
+  renderSidebar();
   saveState();
 }
 
@@ -395,6 +396,7 @@ function addWebPanelAt(url, insertIndex, targetGroupId) {
       } else {
         removeCachedGroup(activeGId);
         renderPanelStrip();
+        renderSidebar();
         saveState();
         return panel.id;
       }
@@ -424,6 +426,7 @@ function addWebPanelAt(url, insertIndex, targetGroupId) {
     renderStatusBar();
   }
 
+  renderSidebar();
   saveState();
   return panel.id;
 }
@@ -483,6 +486,7 @@ function removePanel(panelId) {
     renderPanelStrip();
   }
 
+  renderSidebar();
   saveState();
 }
 


### PR DESCRIPTION
The panel count pills in the sidebar only refreshed on workspace selection change. Add renderSidebar() calls to addPanel(), addWebPanelAt(), and removePanel() so counts update immediately.

Closes #91 