### PR TITLE
feat: Add per-profile panel limit settings

### DIFF
--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -7,6 +7,17 @@ const DEFAULT_FILE_WIDTH = 900;
 const MAX_TERMINAL_PANELS = 20;
 const MAX_WEB_PANELS = 20;
 const MAX_FILE_PANELS = 10;
+
+function getProfileMaxPanels(profile) {
+  const defaults = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
+  if (!profile || !profile.maxPanels) return defaults;
+  return {
+    terminal: profile.maxPanels.terminal ?? defaults.terminal,
+    web: profile.maxPanels.web ?? defaults.web,
+    file: profile.maxPanels.file ?? defaults.file,
+  };
+}
+
 const MAX_URL_HISTORY = 100;
 const MAX_URL_COUNT = 10;
 const URL_DECAY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
@@ -73,6 +84,9 @@ function migrateProfile(profile) {
   if (!profile.groups.find(g => g.id === profile.activeGroupId)) {
     profile.activeGroupId = profile.groups[0]?.id || null;
   }
+  if (!profile.maxPanels) {
+    profile.maxPanels = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
+  }
 }
 
 async function init() {
@@ -122,6 +136,7 @@ async function init() {
         groups: [{ id: groupId, label: 'Work 1', panels: [], lspServers: [] }],
         templates: [],
         urlHistory: [],
+        maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS },
       }],
     };
   }
@@ -302,11 +317,11 @@ async function addPanel(type) {
 
   const profile = getActiveProfile();
   if (!profile) return;
-  const maxLimits = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
+  const maxLimits = getProfileMaxPanels(profile);
   const maxForType = maxLimits[type];
   const profileCount = profile.groups.flatMap(g => g.panels).filter(p => p.type === type).length;
   if (maxForType && profileCount >= maxForType) {
-    showPanelLimitNotification(type);
+    showPanelLimitNotification(type, maxForType);
     return;
   }
 
@@ -360,9 +375,10 @@ function addWebPanelAt(url, insertIndex, targetGroupId) {
 
   const profile = getActiveProfile();
   if (!profile) return null;
+  const maxLimits = getProfileMaxPanels(profile);
   const profileWebCount = profile.groups.flatMap(g => g.panels).filter(p => p.type === 'web').length;
-  if (profileWebCount >= MAX_WEB_PANELS) {
-    showPanelLimitNotification('web');
+  if (profileWebCount >= maxLimits.web) {
+    showPanelLimitNotification('web', maxLimits.web);
     return null;
   }
 
@@ -712,6 +728,7 @@ function addProfile(name) {
     groups: [{ id: groupId, label: 'Work 1', panels: [], lspServers: [] }],
     templates: [],
     urlHistory: [],
+    maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS },
   };
 
   teardownCurrentProfile();

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -25,6 +25,7 @@
   <script src="core/group-cache.js"></script>
   <script src="modals/workspace-modal.js"></script>
   <script src="modals/panel-settings-modal.js"></script>
+  <script src="modals/profile-settings-modal.js"></script>
   <script src="layout/sidebar.js"></script>
   <script src="panels/panel-strip.js"></script>
   <script src="panels/panel-search.js"></script>

--- a/renderer/layout/sidebar.js
+++ b/renderer/layout/sidebar.js
@@ -96,8 +96,18 @@ function renderSidebar() {
     }
   });
 
+  const settingsProfileBtn = document.createElement('button');
+  settingsProfileBtn.className = 'profile-action-btn';
+  settingsProfileBtn.textContent = '\u2699';
+  settingsProfileBtn.title = 'Profile settings';
+  settingsProfileBtn.addEventListener('click', () => {
+    if (!profile) return;
+    showProfileSettingsModal(profile);
+  });
+
   profileActions.appendChild(addProfileBtn);
   profileActions.appendChild(renameProfileBtn);
+  profileActions.appendChild(settingsProfileBtn);
   profileActions.appendChild(deleteProfileBtn);
 
   profileSection.appendChild(profileSelect);

--- a/renderer/modals/panel-limit-modal.js
+++ b/renderer/modals/panel-limit-modal.js
@@ -1,10 +1,12 @@
 // panel-limit-modal.js - Notification popup when panel limit is reached
 
-function showPanelLimitNotification(type) {
+function showPanelLimitNotification(type, limit) {
   if (document.querySelector('.panel-limit-overlay')) return;
 
-  const limits = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
-  const limit = limits[type] || '?';
+  if (limit == null) {
+    const limits = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
+    limit = limits[type] || '?';
+  }
 
   const overlay = document.createElement('div');
   overlay.className = 'modal-overlay panel-limit-overlay';

--- a/renderer/modals/profile-settings-modal.js
+++ b/renderer/modals/profile-settings-modal.js
@@ -1,0 +1,97 @@
+// profile-settings-modal.js - Per-profile panel limit settings
+
+function showProfileSettingsModal(profile) {
+  if (!profile) return;
+  if (document.querySelector('.profile-settings-overlay')) return;
+
+  const maxPanels = getProfileMaxPanels(profile);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay profile-settings-overlay';
+
+  const container = document.createElement('div');
+  container.className = 'modal-container';
+  container.style.width = '420px';
+
+  const header = document.createElement('div');
+  header.className = 'modal-header';
+  header.textContent = 'Profile Settings';
+  container.appendChild(header);
+
+  const fields = [
+    { key: 'terminal', label: 'Max Terminal Panels' },
+    { key: 'web', label: 'Max Web Panels' },
+    { key: 'file', label: 'Max File Panels' },
+  ];
+
+  const inputs = {};
+
+  for (const { key, label } of fields) {
+    const field = document.createElement('div');
+    field.className = 'modal-field';
+
+    const lbl = document.createElement('label');
+    lbl.className = 'modal-label';
+    lbl.textContent = label;
+
+    const input = document.createElement('input');
+    input.className = 'modal-input';
+    input.type = 'number';
+    input.min = '0';
+    input.max = '50';
+    input.value = maxPanels[key];
+    inputs[key] = input;
+
+    field.appendChild(lbl);
+    field.appendChild(input);
+    container.appendChild(field);
+  }
+
+  const footer = document.createElement('div');
+  footer.className = 'modal-footer';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'modal-btn modal-btn-cancel';
+  cancelBtn.textContent = 'Cancel';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.className = 'modal-btn modal-btn-create';
+  saveBtn.textContent = 'Save';
+
+  footer.appendChild(cancelBtn);
+  footer.appendChild(saveBtn);
+  container.appendChild(footer);
+  overlay.appendChild(container);
+
+  function dismiss() {
+    overlay.remove();
+    document.removeEventListener('keydown', onKey);
+  }
+
+  function onKey(e) {
+    if (e.key === 'Escape') { e.preventDefault(); dismiss(); }
+  }
+
+  function save() {
+    const newMaxPanels = {};
+    for (const { key } of fields) {
+      const val = parseInt(inputs[key].value, 10);
+      newMaxPanels[key] = isNaN(val) ? maxPanels[key] : Math.max(0, Math.min(50, val));
+    }
+    profile.maxPanels = newMaxPanels;
+    saveState();
+    renderStatusBar();
+    dismiss();
+  }
+
+  cancelBtn.addEventListener('click', dismiss);
+  saveBtn.addEventListener('click', save);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) dismiss();
+  });
+  document.addEventListener('keydown', onKey);
+
+  document.body.appendChild(overlay);
+  inputs.terminal.focus();
+  inputs.terminal.select();
+}

--- a/renderer/panels/status-bar.js
+++ b/renderer/panels/status-bar.js
@@ -7,10 +7,11 @@ function renderStatusBar() {
   const profile = getActiveProfile();
   const allPanels = profile ? profile.groups.flatMap(g => g.panels) : [];
 
+  const maxLimits = getProfileMaxPanels(profile);
   const types = [
-    { type: 'terminal', label: 'Terminal', max: MAX_TERMINAL_PANELS },
-    { type: 'web', label: 'Web', max: MAX_WEB_PANELS },
-    { type: 'file', label: 'Files', max: MAX_FILE_PANELS },
+    { type: 'terminal', label: 'Terminal', max: maxLimits.terminal },
+    { type: 'web', label: 'Web', max: maxLimits.web },
+    { type: 'file', label: 'Files', max: maxLimits.file },
   ];
 
   const profileLabel = profile ? `<span class="status-bar-item status-bar-profile">${profile.name}</span>` : '';


### PR DESCRIPTION
Add a settings gear button to the sidebar profile actions that opens a modal for configuring max terminal, web, and file panel limits on a per-profile basis, replacing the previous global constants.

Closes #93 