### PR TITLE
feat: Add bookmarks page for empty web panels

### DIFF
--- a/main.js
+++ b/main.js
@@ -1019,6 +1019,20 @@ app.whenReady().then(async () => {
           label: 'Copy Page URL',
           click: () => clipboard.writeText(contents.getURL()),
         });
+        menuTemplate.push({ type: 'separator' });
+        menuTemplate.push({
+          label: 'Bookmark This Page',
+          click: () => {
+            const host = contents.hostWebContents;
+            if (host && !host.isDestroyed()) {
+              host.send('webview:bookmark-page', {
+                webContentsId: contents.id,
+                url: contents.getURL(),
+                title: contents.getTitle(),
+              });
+            }
+          },
+        });
 
         const menu = Menu.buildFromTemplate(menuTemplate);
         menu.popup();

--- a/preload.js
+++ b/preload.js
@@ -69,6 +69,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('webview:open-in-new-panel', listener);
     return () => ipcRenderer.removeListener('webview:open-in-new-panel', listener);
   },
+  onWebviewBookmarkPage: (callback) => {
+    const listener = (_, data) => callback(data);
+    ipcRenderer.on('webview:bookmark-page', listener);
+    return () => ipcRenderer.removeListener('webview:bookmark-page', listener);
+  },
   searchFindInPage: (webContentsId, text, options) =>
     ipcRenderer.invoke('search:findInPage', { webContentsId, text, options }),
   searchStopFindInPage: (webContentsId, action) =>

--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -69,6 +69,7 @@ function getActiveGroupId() {
 function migrateProfile(profile) {
   if (!profile.templates) profile.templates = [];
   if (!profile.urlHistory) profile.urlHistory = [];
+  if (!profile.bookmarks) profile.bookmarks = [];
   for (const entry of profile.urlHistory) {
     if (!entry.count) entry.count = 1;
     if (!entry.lastAccessed) entry.lastAccessed = entry.timestamp || Date.now();
@@ -136,6 +137,7 @@ async function init() {
         groups: [{ id: groupId, label: 'Work 1', panels: [], lspServers: [] }],
         templates: [],
         urlHistory: [],
+        bookmarks: [],
         maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS },
       }],
     };
@@ -682,6 +684,42 @@ function applyUrlHistoryDecay() {
   if (changed) saveState();
 }
 
+// ── Bookmark operations ──────────────────────────
+
+function addBookmark(url, title) {
+  const profile = getActiveProfile();
+  if (!profile) return null;
+  if (profile.bookmarks.some(b => b.url === url)) return null;
+  const bookmark = { id: generateId(), url, title: title || '', addedAt: Date.now() };
+  profile.bookmarks.push(bookmark);
+  saveState();
+  return bookmark;
+}
+
+function removeBookmark(bookmarkId) {
+  const profile = getActiveProfile();
+  if (!profile) return;
+  profile.bookmarks = profile.bookmarks.filter(b => b.id !== bookmarkId);
+  saveState();
+}
+
+function getFilteredBookmarks(query) {
+  const profile = getActiveProfile();
+  if (!profile) return [];
+  const q = (query || '').toLowerCase().trim();
+  let results = profile.bookmarks;
+  if (q) {
+    results = results.filter(b => b.url.toLowerCase().includes(q) || (b.title && b.title.toLowerCase().includes(q)));
+  }
+  return results.slice().sort((a, b) => (b.addedAt || 0) - (a.addedAt || 0));
+}
+
+function isBookmarked(url) {
+  const profile = getActiveProfile();
+  if (!profile) return false;
+  return profile.bookmarks.some(b => b.url === url);
+}
+
 // ── Profile operations ────────────────────────────
 
 function teardownCurrentProfile() {
@@ -728,6 +766,7 @@ function addProfile(name) {
     groups: [{ id: groupId, label: 'Work 1', panels: [], lspServers: [] }],
     templates: [],
     urlHistory: [],
+    bookmarks: [],
     maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS },
   };
 

--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -26,6 +26,25 @@ if (window.electronAPI.onWebviewOpenInNewPanel) {
     }
   });
 }
+if (window.electronAPI.onWebviewBookmarkPage) {
+  window.electronAPI.onWebviewBookmarkPage(({ webContentsId, url, title }) => {
+    if (!url || url === 'about:blank' || url.startsWith('data:')) return;
+    const entry = webviewRegistry.get(webContentsId);
+    if (!entry) return;
+    if (!isBookmarked(url)) {
+      addBookmark(url, title);
+    }
+    // Update the star button for the relevant panel
+    const panelEl = document.querySelector(`[data-panel-id="${entry.panelId}"]`);
+    if (panelEl) {
+      const bmBtn = panelEl.querySelector('.bookmark-btn');
+      if (bmBtn) {
+        bmBtn.textContent = '\u2605';
+        bmBtn.classList.add('bookmarked');
+      }
+    }
+  });
+}
 
 function isAbortedError(err) {
   return err && err.message && err.message.includes('ERR_ABORTED');
@@ -67,6 +86,11 @@ function renderWebPanel(panel, container) {
   refreshBtn.textContent = '\u21bb';
   refreshBtn.title = 'Refresh';
 
+  const bookmarkBtn = document.createElement('button');
+  bookmarkBtn.className = 'nav-btn bookmark-btn';
+  bookmarkBtn.textContent = '\u2606';
+  bookmarkBtn.title = 'Bookmark this page';
+
   const urlInputWrapper = document.createElement('div');
   urlInputWrapper.className = 'url-input-wrapper';
 
@@ -85,6 +109,7 @@ function renderWebPanel(panel, container) {
   urlBar.appendChild(backBtn);
   urlBar.appendChild(forwardBtn);
   urlBar.appendChild(refreshBtn);
+  urlBar.appendChild(bookmarkBtn);
   urlBar.appendChild(urlInputWrapper);
   container.appendChild(urlBar);
 
@@ -153,6 +178,124 @@ function renderWebPanel(panel, container) {
   // wrapper hasn't been appended to the panel strip yet.
   webview.src = initialUrl;
 
+  // ── Bookmark overlay ────────────────────────────
+  container.style.position = 'relative';
+
+  const bookmarkOverlay = document.createElement('div');
+  bookmarkOverlay.className = 'bookmark-overlay';
+  bookmarkOverlay.hidden = true;
+
+  const bmSearchInput = document.createElement('input');
+  bmSearchInput.type = 'text';
+  bmSearchInput.className = 'bookmark-search-input';
+  bmSearchInput.placeholder = 'Search bookmarks...';
+
+  const bmGrid = document.createElement('div');
+  bmGrid.className = 'bookmark-grid';
+
+  bookmarkOverlay.appendChild(bmSearchInput);
+  bookmarkOverlay.appendChild(bmGrid);
+  container.appendChild(bookmarkOverlay);
+
+  function updateBookmarkOverlay() {
+    const query = bmSearchInput.value;
+    const bookmarks = getFilteredBookmarks(query);
+    bmGrid.innerHTML = '';
+
+    if (bookmarks.length === 0) {
+      const emptyMsg = document.createElement('div');
+      emptyMsg.className = 'bookmark-empty';
+      emptyMsg.textContent = query
+        ? 'No matching bookmarks.'
+        : 'No bookmarks yet. Navigate to a page and click \u2606 to add one.';
+      bmGrid.appendChild(emptyMsg);
+      return;
+    }
+
+    bookmarks.forEach(bm => {
+      const tile = document.createElement('div');
+      tile.className = 'bookmark-tile';
+
+      const iconEl = document.createElement('div');
+      iconEl.className = 'bookmark-tile-icon';
+      try {
+        const domain = new URL(bm.url).hostname;
+        iconEl.textContent = domain.replace(/^www\./, '').charAt(0).toUpperCase();
+      } catch { iconEl.textContent = '?'; }
+
+      const titleEl = document.createElement('div');
+      titleEl.className = 'bookmark-tile-title';
+      titleEl.textContent = bm.title || bm.url;
+      titleEl.title = bm.title || bm.url;
+
+      const urlEl = document.createElement('div');
+      urlEl.className = 'bookmark-tile-url';
+      try { urlEl.textContent = new URL(bm.url).hostname; } catch { urlEl.textContent = bm.url; }
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.className = 'bookmark-tile-delete';
+      deleteBtn.textContent = '\u00d7';
+      deleteBtn.title = 'Remove bookmark';
+      deleteBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        removeBookmark(bm.id);
+        updateBookmarkOverlay();
+      });
+
+      tile.appendChild(deleteBtn);
+      tile.appendChild(iconEl);
+      tile.appendChild(titleEl);
+      tile.appendChild(urlEl);
+
+      tile.addEventListener('click', () => navigate(bm.url));
+      bmGrid.appendChild(tile);
+    });
+  }
+
+  function showBookmarkOverlay() {
+    bookmarkOverlay.hidden = false;
+    bmSearchInput.value = '';
+    updateBookmarkOverlay();
+  }
+
+  function hideBookmarkOverlay() {
+    bookmarkOverlay.hidden = true;
+  }
+
+  bmSearchInput.addEventListener('input', () => updateBookmarkOverlay());
+  bmSearchInput.addEventListener('mousedown', e => e.stopPropagation());
+
+  if (initialUrl === 'about:blank') showBookmarkOverlay();
+
+  // ── Bookmark button logic ───────────────────────
+  function updateBookmarkBtn() {
+    const currentUrl = urlInput.value;
+    if (!currentUrl || currentUrl === 'about:blank' || currentUrl.startsWith('data:')) {
+      bookmarkBtn.style.display = 'none';
+      return;
+    }
+    bookmarkBtn.style.display = '';
+    const marked = isBookmarked(currentUrl);
+    bookmarkBtn.textContent = marked ? '\u2605' : '\u2606';
+    bookmarkBtn.classList.toggle('bookmarked', marked);
+  }
+
+  bookmarkBtn.addEventListener('click', () => {
+    const currentUrl = urlInput.value;
+    if (!currentUrl || currentUrl === 'about:blank') return;
+    if (isBookmarked(currentUrl)) {
+      const profile = getActiveProfile();
+      const bm = profile.bookmarks.find(b => b.url === currentUrl);
+      if (bm) removeBookmark(bm.id);
+    } else {
+      const title = webview.getTitle ? webview.getTitle() : '';
+      addBookmark(currentUrl, title);
+    }
+    updateBookmarkBtn();
+  });
+
+  updateBookmarkBtn();
+
   console.log(`[WebPanel] Created webview panel=${panel.id} url=${panel.url || 'about:blank'} partition=persist:webpanels`);
 
   let lastRealUrl = panel.url || '';
@@ -220,6 +363,7 @@ function renderWebPanel(panel, container) {
   const navigate = (raw) => {
     let url = raw.trim();
     if (!url) return;
+    hideBookmarkOverlay();
     if (navigateInFlight) {
       console.log(`[WebPanel] navigate blocked — already in flight panel=${panel.id}`);
       return;
@@ -343,6 +487,13 @@ function renderWebPanel(panel, container) {
         window.electronAPI.cdpUpdateWebview(webview._webContentsId, e.url, undefined);
       }
     }
+    // Show/hide bookmark overlay based on URL
+    if (e.url === 'about:blank') {
+      showBookmarkOverlay();
+    } else {
+      hideBookmarkOverlay();
+    }
+    updateBookmarkBtn();
     if (window.electronAPI.debugGetCookieCount) {
       window.electronAPI.debugGetCookieCount().then(info => {
         console.log(`[WebPanel] Cookies after navigate: total=${info.total} session=${info.session} persistent=${info.persistent}`);
@@ -357,6 +508,7 @@ function renderWebPanel(panel, container) {
       updatePanelUrl(panel.id, e.url);
       addToUrlHistory(e.url, '');
     }
+    updateBookmarkBtn();
   });
 
   webview.addEventListener('did-fail-load', e => {

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1554,3 +1554,149 @@ webview {
   width: 3px !important;
   margin-left: 3px;
 }
+
+/* ── Bookmark overlay ──────────────────────────── */
+
+.bookmark-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  background: #1e1e2e;
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.bookmark-overlay[hidden] {
+  display: none;
+}
+
+.bookmark-overlay::-webkit-scrollbar { width: 4px; }
+.bookmark-overlay::-webkit-scrollbar-track { background: transparent; }
+.bookmark-overlay::-webkit-scrollbar-thumb { background: #333; border-radius: 2px; }
+
+.bookmark-search-input {
+  background: #12121e;
+  border: 1px solid #334;
+  color: #ccc;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  outline: none;
+  margin-bottom: 16px;
+  width: 100%;
+  max-width: 400px;
+  align-self: center;
+}
+
+.bookmark-search-input:focus {
+  border-color: #533483;
+  color: #e0e0e0;
+}
+
+.bookmark-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+  align-content: start;
+  flex: 1;
+}
+
+.bookmark-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 10px 12px;
+  background: #22223a;
+  border: 1px solid #2a2a3e;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  gap: 6px;
+  overflow: hidden;
+}
+
+.bookmark-tile:hover {
+  background: #2a2a4e;
+  border-color: #533483;
+}
+
+.bookmark-tile-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: #3d2b6e;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: #e0d0ff;
+  flex-shrink: 0;
+}
+
+.bookmark-tile-title {
+  font-size: 12px;
+  color: #ccc;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.bookmark-tile-url {
+  font-size: 10px;
+  color: #667;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.bookmark-tile-delete {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: none;
+  border: none;
+  color: #556;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 3px;
+  opacity: 0;
+  transition: opacity 0.12s, color 0.12s;
+}
+
+.bookmark-tile:hover .bookmark-tile-delete {
+  opacity: 1;
+}
+
+.bookmark-tile-delete:hover {
+  color: #ff6b6b;
+  background: #3a1a1a;
+}
+
+.bookmark-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: #556;
+  font-size: 13px;
+  padding: 40px 0;
+}
+
+.bookmark-btn.bookmarked {
+  color: #f1fa8c;
+  border-color: #665830;
+}
+
+.bookmark-btn.bookmarked:hover {
+  color: #f5fcaa;
+  background: #2a2a4e;
+  border-color: #887040;
+}


### PR DESCRIPTION
Show a searchable, scrollable grid of bookmarks when a web panel has no URL instead of a blank white page. Users can add/remove bookmarks via a star button in the URL bar or the right-click context menu. Bookmarks are stored per-profile and persist across restarts.

Closes #101