### PR TITLE
fix: Add cleanup lifecycle for web panels to prevent renderer process…

### DIFF
--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -30,6 +30,9 @@ const activeTerminals = new Map();
 // Map<panelId, { editor, dispose }>
 const activeEditors = new Map();
 
+// Map<panelId, { cleanup }>
+const activeWebPanels = new Map();
+
 // Map<serverId, { groupId, serverKey, cleanup }>
 const activeLspServers = new Map();
 
@@ -306,6 +309,10 @@ function killGroupTerminals(group) {
       const { dispose } = activeEditors.get(p.id);
       if (dispose) dispose();
     }
+    if (p.type === 'web' && activeWebPanels.has(p.id)) {
+      const { cleanup } = activeWebPanels.get(p.id);
+      if (cleanup) cleanup();
+    }
   });
 }
 
@@ -478,6 +485,10 @@ function removePanel(panelId) {
   if (activeEditors.has(panelId)) {
     const { dispose } = activeEditors.get(panelId);
     if (dispose) dispose();
+  }
+  if (activeWebPanels.has(panelId)) {
+    const { cleanup } = activeWebPanels.get(panelId);
+    if (cleanup) cleanup();
   }
 
   group.panels = group.panels.filter(p => p.id !== panelId);
@@ -701,6 +712,7 @@ function teardownCurrentProfile() {
   // Clear active maps
   activeTerminals.clear();
   activeEditors.clear();
+  activeWebPanels.clear();
   activeLspServers.clear();
 
   // Destroy all panel searches

--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -456,4 +456,18 @@ function renderWebPanel(panel, container) {
       }
     }
   });
+
+  // Cleanup function — mirrors the pattern used by mountTerminal() in term-panel.js
+  const cleanup = () => {
+    const wcId = webview._webContentsId;
+    if (wcId !== undefined) {
+      webviewRegistry.delete(wcId);
+      if (window.electronAPI.cdpUnregisterWebview) {
+        window.electronAPI.cdpUnregisterWebview(wcId);
+      }
+    }
+    destroyPanelSearch(panel.id);
+    activeWebPanels.delete(panel.id);
+  };
+  activeWebPanels.set(panel.id, { cleanup });
 }


### PR DESCRIPTION
… leaks

Web panels (webviews) had no cleanup when removed, cached-evicted, or profile-switched, causing renderer processes to accumulate indefinitely. Adds activeWebPanels map following the existing terminal/editor pattern, with cleanup that unregisters from webviewRegistry and calls cdpUnregisterWebview to release main-process references.

Closes #104