### PR TITLE
fix: Hide webview compositor layer so bookmark overlay is visible

### DIFF
--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -254,12 +254,14 @@ function renderWebPanel(panel, container) {
 
   function showBookmarkOverlay() {
     bookmarkOverlay.hidden = false;
+    webview.classList.add('webview-hidden');
     bmSearchInput.value = '';
     updateBookmarkOverlay();
   }
 
   function hideBookmarkOverlay() {
     bookmarkOverlay.hidden = true;
+    webview.classList.remove('webview-hidden');
   }
 
   bmSearchInput.addEventListener('input', () => updateBookmarkOverlay());

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1555,6 +1555,14 @@ webview {
   margin-left: 3px;
 }
 
+webview.webview-hidden {
+  visibility: hidden;
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
 /* ── Bookmark overlay ──────────────────────────── */
 
 .bookmark-overlay {


### PR DESCRIPTION
Electron's <webview> renders on a separate compositor layer that always paints on top of sibling DOM elements regardless of z-index. Toggle visibility: hidden on the webview when the bookmark overlay is shown.

Closes #101