### PR TITLE
fix: Route terminal link clicks to web panels instead of external bro…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "monaco-editor": "^0.55.1",
         "node-pty": "^1.0.0"
@@ -804,6 +805,12 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
       "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "monaco-editor": "^0.55.1",
     "node-pty": "^1.0.0"

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -21,6 +21,7 @@
   <script src="../node_modules/@xterm/xterm/lib/xterm.js"></script>
   <script src="../node_modules/@xterm/addon-fit/lib/addon-fit.js"></script>
   <script src="../node_modules/@xterm/addon-search/lib/addon-search.js"></script>
+  <script src="../node_modules/@xterm/addon-web-links/lib/addon-web-links.js"></script>
   <script src="core/app.js"></script>
   <script src="core/group-cache.js"></script>
   <script src="modals/workspace-modal.js"></script>

--- a/renderer/panels/term-panel.js
+++ b/renderer/panels/term-panel.js
@@ -19,6 +19,12 @@ async function mountTerminal(panel, container) {
   }
 
   // Create a new xterm Terminal
+  const openLinkInPanel = (url) => {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      addWebPanelAfter(panel.id, url);
+    }
+  };
+
   const terminal = new Terminal({
     cursorBlink: true,
     fontSize: 13,
@@ -30,6 +36,9 @@ async function mountTerminal(panel, container) {
       selectionBackground: '#3d2b6e',
     },
     scrollback: 5000,
+    linkHandler: {
+      activate: (_event, text) => openLinkInPanel(text),
+    },
   });
 
   const fitAddon = new FitAddon.FitAddon();
@@ -37,6 +46,9 @@ async function mountTerminal(panel, container) {
 
   const searchAddon = new SearchAddon.SearchAddon();
   terminal.loadAddon(searchAddon);
+
+  const webLinksAddon = new WebLinksAddon.WebLinksAddon((_event, url) => openLinkInPanel(url));
+  terminal.loadAddon(webLinksAddon);
 
   terminal.open(container);
 


### PR DESCRIPTION
…wser

Add @xterm/addon-web-links for plain-text URL detection and a custom linkHandler for OSC 8 hyperlinks so clicking any link in a terminal panel opens a web panel beside it rather than launching the system browser.

Closes #107