### PR TITLE
feat: Allow opening PDF files in web panel

### DIFF
--- a/main.js
+++ b/main.js
@@ -119,7 +119,7 @@ ipcMain.handle('state:save', (_, state) => {
 });
 
 // Terminal IPC
-ipcMain.handle('terminal:create', (event, { cols, rows, cwd, initialCommand, profileId, groupId }) => {
+ipcMain.handle('terminal:create', (event, { cols, rows, cwd, initialCommand, profileId, groupId, interceptPdf }) => {
   if (!pty) return { error: 'node-pty not available. Run: npm run postinstall' };
 
   const id = ++termIdCounter;
@@ -141,6 +141,7 @@ ipcMain.handle('terminal:create', (event, { cols, rows, cwd, initialCommand, pro
   }
   if (profileId) termEnv.WORKLAYER_PROFILE_ID = String(profileId);
   if (groupId) termEnv.WORKLAYER_GROUP_ID = String(groupId);
+  if (interceptPdf !== false) termEnv.WORKLAYER_INTERCEPT_PDF = '1';
 
   const term = pty.spawn(shell, [], {
     name: 'xterm-256color',
@@ -565,7 +566,7 @@ curl -s -o /dev/null "http://127.0.0.1:${browserInterceptPort}/open?token=${brow
   // open wrapper: intercepts URLs, passes non-URLs to /usr/bin/open
   const openWrapperPath = path.join(browserHelperDir, 'open');
   const openWrapperScript = `#!/bin/sh
-# Worklayer open wrapper — intercepts URL arguments
+# Worklayer open wrapper — intercepts URL arguments and PDF files
 IS_URL=0
 TARGET=""
 PASSTHROUGH_ARGS=""
@@ -574,6 +575,17 @@ for arg in "$@"; do
     http://*|https://*)
       IS_URL=1
       TARGET="$arg"
+      ;;
+    *.pdf|*.PDF)
+      if [ "$WORKLAYER_INTERCEPT_PDF" = "1" ]; then
+        IS_URL=1
+        case "$arg" in
+          /*) TARGET="file://$arg" ;;
+          *)  TARGET="file://$(cd "$(dirname "$arg")" 2>/dev/null && pwd)/$(basename "$arg")" ;;
+        esac
+      else
+        if [ -z "$TARGET" ]; then TARGET="$arg"; else PASSTHROUGH_ARGS="$PASSTHROUGH_ARGS $arg"; fi
+      fi
       ;;
     -*)
       PASSTHROUGH_ARGS="$PASSTHROUGH_ARGS $arg"

--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -18,6 +18,11 @@ function getProfileMaxPanels(profile) {
   };
 }
 
+function getProfileInterceptPdf(profile) {
+  if (!profile || profile.interceptPdf === undefined) return true;
+  return !!profile.interceptPdf;
+}
+
 const MAX_URL_HISTORY = 100;
 const MAX_URL_COUNT = 10;
 const URL_DECAY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week

--- a/renderer/modals/profile-settings-modal.js
+++ b/renderer/modals/profile-settings-modal.js
@@ -47,6 +47,28 @@ function showProfileSettingsModal(profile) {
     container.appendChild(field);
   }
 
+  // ── PDF interception toggle ──
+  const pdfField = document.createElement('div');
+  pdfField.className = 'modal-field';
+  pdfField.style.flexDirection = 'row';
+  pdfField.style.alignItems = 'center';
+  pdfField.style.gap = '8px';
+
+  const pdfCheckbox = document.createElement('input');
+  pdfCheckbox.type = 'checkbox';
+  pdfCheckbox.id = 'intercept-pdf-checkbox';
+  pdfCheckbox.checked = getProfileInterceptPdf(profile);
+
+  const pdfLabel = document.createElement('label');
+  pdfLabel.className = 'modal-label';
+  pdfLabel.setAttribute('for', 'intercept-pdf-checkbox');
+  pdfLabel.textContent = 'Open PDFs in panel';
+  pdfLabel.style.marginBottom = '0';
+
+  pdfField.appendChild(pdfCheckbox);
+  pdfField.appendChild(pdfLabel);
+  container.appendChild(pdfField);
+
   const footer = document.createElement('div');
   footer.className = 'modal-footer';
 
@@ -79,6 +101,7 @@ function showProfileSettingsModal(profile) {
       newMaxPanels[key] = isNaN(val) ? maxPanels[key] : Math.max(0, Math.min(50, val));
     }
     profile.maxPanels = newMaxPanels;
+    profile.interceptPdf = pdfCheckbox.checked;
     saveState();
     renderStatusBar();
     dismiss();

--- a/renderer/panels/file-panel.js
+++ b/renderer/panels/file-panel.js
@@ -358,6 +358,11 @@ function renderFilePanel(panel, container) {
 
   async function openFile(filePath, skipDirtyCheck) {
     if (isBinaryFile(filePath)) {
+      const ext = filePath.split('.').pop().toLowerCase();
+      if (ext === 'pdf') {
+        addWebPanelAfter(panel.id, 'file://' + filePath);
+        return;
+      }
       if (currentEditor) {
         currentEditor.setValue('');
         currentEditor.updateOptions({ readOnly: true });

--- a/renderer/panels/term-panel.js
+++ b/renderer/panels/term-panel.js
@@ -69,6 +69,7 @@ async function mountTerminal(panel, container) {
     initialCommand: panel.initialCommand || undefined,
     profileId: getActiveProfile()?.id,
     groupId: getActiveGroupId(),
+    interceptPdf: getProfileInterceptPdf(getActiveProfile()),
   });
 
   if (error) {

--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -171,6 +171,7 @@ function renderWebPanel(panel, container) {
   const webview = document.createElement('webview');
   webview.setAttribute('allowpopups', '');
   webview.setAttribute('partition', 'persist:webpanels');
+  webview.setAttribute('webpreferences', 'plugins');
   const initialUrl = panel.url || 'about:blank';
   const webviewWrapper = document.createElement('div');
   webviewWrapper.className = 'webview-wrapper';
@@ -274,7 +275,7 @@ function renderWebPanel(panel, container) {
   // ── Bookmark button logic ───────────────────────
   function updateBookmarkBtn() {
     const currentUrl = urlInput.value;
-    if (!currentUrl || currentUrl === 'about:blank' || currentUrl.startsWith('data:')) {
+    if (!currentUrl || currentUrl === 'about:blank' || currentUrl.startsWith('data:') || currentUrl.startsWith('file://')) {
       bookmarkBtn.style.display = 'none';
       return;
     }
@@ -389,7 +390,7 @@ function renderWebPanel(panel, container) {
     });
     urlInput.value = url;
     updatePanelUrl(panel.id, url);
-    addToUrlHistory(url, '');
+    if (!url.startsWith('file://')) addToUrlHistory(url, '');
   };
 
   backBtn.addEventListener('click', () => webview.goBack());
@@ -485,7 +486,7 @@ function renderWebPanel(panel, container) {
       crashRetryCount = 0;
       urlInput.value = e.url;
       updatePanelUrl(panel.id, e.url);
-      addToUrlHistory(e.url, '');
+      if (!e.url.startsWith('file://')) addToUrlHistory(e.url, '');
       if (window.electronAPI.cdpUpdateWebview && webview._webContentsId) {
         window.electronAPI.cdpUpdateWebview(webview._webContentsId, e.url, undefined);
       }
@@ -509,7 +510,7 @@ function renderWebPanel(panel, container) {
       lastRealUrl = e.url;
       urlInput.value = e.url;
       updatePanelUrl(panel.id, e.url);
-      addToUrlHistory(e.url, '');
+      if (!e.url.startsWith('file://')) addToUrlHistory(e.url, '');
     }
     updateBookmarkBtn();
   });


### PR DESCRIPTION
Add PDF interception in the open wrapper and file panel so PDFs open in a webview instead of the system viewer. Includes a per-profile toggle in settings, excludes file:// URLs from bookmark/history, and enables the plugins webpreference for PDF rendering.

Closes #112 