### PR TITLE
feat: Allow opening image files in web panel

### DIFF
--- a/main.js
+++ b/main.js
@@ -566,7 +566,7 @@ curl -s -o /dev/null "http://127.0.0.1:${browserInterceptPort}/open?token=${brow
   // open wrapper: intercepts URLs, passes non-URLs to /usr/bin/open
   const openWrapperPath = path.join(browserHelperDir, 'open');
   const openWrapperScript = `#!/bin/sh
-# Worklayer open wrapper — intercepts URL arguments and PDF files
+# Worklayer open wrapper — intercepts URL arguments, PDF files, and image files
 IS_URL=0
 TARGET=""
 PASSTHROUGH_ARGS=""
@@ -586,6 +586,13 @@ for arg in "$@"; do
       else
         if [ -z "$TARGET" ]; then TARGET="$arg"; else PASSTHROUGH_ARGS="$PASSTHROUGH_ARGS $arg"; fi
       fi
+      ;;
+    *.png|*.PNG|*.jpg|*.JPG|*.jpeg|*.JPEG|*.gif|*.GIF|*.bmp|*.BMP|*.ico|*.ICO|*.webp|*.WEBP|*.svg|*.SVG)
+      IS_URL=1
+      case "$arg" in
+        /*) TARGET="file://$arg" ;;
+        *)  TARGET="file://$(cd "$(dirname "$arg")" 2>/dev/null && pwd)/$(basename "$arg")" ;;
+      esac
       ;;
     -*)
       PASSTHROUGH_ARGS="$PASSTHROUGH_ARGS $arg"

--- a/renderer/panels/file-panel.js
+++ b/renderer/panels/file-panel.js
@@ -13,6 +13,10 @@ const BINARY_EXTENSIONS = new Set([
   'sqlite', 'db',
 ]);
 
+const IMAGE_EXTENSIONS = new Set([
+  'png', 'jpg', 'jpeg', 'gif', 'bmp', 'ico', 'webp', 'svg',
+]);
+
 const EXT_LANG_MAP = {
   js: 'javascript', jsx: 'javascript', mjs: 'javascript', cjs: 'javascript',
   ts: 'typescript', tsx: 'typescript',
@@ -360,6 +364,10 @@ function renderFilePanel(panel, container) {
     if (isBinaryFile(filePath)) {
       const ext = filePath.split('.').pop().toLowerCase();
       if (ext === 'pdf') {
+        addWebPanelAfter(panel.id, 'file://' + filePath);
+        return;
+      }
+      if (IMAGE_EXTENSIONS.has(ext)) {
         addWebPanelAfter(panel.id, 'file://' + filePath);
         return;
       }


### PR DESCRIPTION
Intercept image files (png, jpg, jpeg, gif, bmp, ico, webp, svg) from terminal `open` command and file explorer, opening them in a web panel beside the source panel instead of an external app.

Closes #45 