### PR TITLE
perf: Reduce main process bottlenecks from heavy web panel pages

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,9 +7,10 @@ const http = require('http');
 const crypto = require('crypto');
 
 const DEBUG_LOG = '/tmp/worklayer-debug.log';
+const logStream = fs.createWriteStream(DEBUG_LOG, { flags: 'a' });
 function debugLog(...args) {
   const msg = `[${new Date().toISOString()}] ${args.join(' ')}\n`;
-  try { fs.appendFileSync(DEBUG_LOG, msg); } catch (_) {}
+  logStream.write(msg);
 }
 debugLog('=== main.js loaded ===');
 
@@ -880,6 +881,13 @@ app.whenReady().then(async () => {
   // Strip anti-framing headers so webview panels can load any site.
   // Only affects the 'persist:webpanels' session — main window is untouched.
   ses.webRequest.onHeadersReceived((details, callback) => {
+    // Anti-framing headers only matter for frame navigations — skip everything
+    // else so heavy pages with hundreds of sub-resources don't bottleneck here.
+    if (details.resourceType !== 'mainFrame' && details.resourceType !== 'subFrame') {
+      callback({ cancel: false });
+      return;
+    }
+
     const headers = Object.assign({}, details.responseHeaders);
 
     for (const key of Object.keys(headers)) {
@@ -911,9 +919,11 @@ app.whenReady().then(async () => {
     contents.on('did-fail-load', (event, errorCode, errorDescription, validatedURL) => {
       debugLog('[did-fail-load] code:', errorCode, 'desc:', errorDescription, 'url:', validatedURL);
     });
-    contents.on('console-message', (event, level, message, line, sourceId) => {
-      debugLog('[webcontents-console]', `level:${level}`, message);
-    });
+    if (process.env.WORKLAYER_DEBUG_CONSOLE === '1') {
+      contents.on('console-message', (event, level, message, line, sourceId) => {
+        debugLog('[webcontents-console]', `level:${level}`, message);
+      });
+    }
 
     // Intercept keystrokes in webview contents when search capture is active
     if (contents.getType() === 'webview') {

--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -498,11 +498,6 @@ function renderWebPanel(panel, container) {
       hideBookmarkOverlay();
     }
     updateBookmarkBtn();
-    if (window.electronAPI.debugGetCookieCount) {
-      window.electronAPI.debugGetCookieCount().then(info => {
-        console.log(`[WebPanel] Cookies after navigate: total=${info.total} session=${info.session} persistent=${info.persistent}`);
-      }).catch(() => {});
-    }
   });
 
   webview.addEventListener('did-navigate-in-page', e => {


### PR DESCRIPTION
Closes #116

Heavy websites (e.g. Confluence) in web panels were making the entire app laggy because several main-process mechanisms blocked the event loop:

- Filter onHeadersReceived to only frame navigations (mainFrame/subFrame) since X-Frame-Options and frame-ancestors CSP only apply to frames, skipping hundreds of sub-resource requests per page load
- Gate console-message handler behind WORKLAYER_DEBUG_CONSOLE=1 env var to stop synchronous disk writes for every webview console message
- Replace synchronous fs.appendFileSync in debugLog with async write stream
- Remove debug cookie count logging from did-navigate handler