### PR TITLE
feat: Add network/console debugging tools to MCP and debug panel UI

### DIFF
--- a/main.js
+++ b/main.js
@@ -47,6 +47,13 @@ let termIdCounter = 0;
 const webviewPanelMap = new Map(); // webContentsId -> { panelId, url, title }
 const attachedDebuggers = new Map(); // webContentsId -> true
 
+// CDP debugging buffers
+const networkRequests = new Map();  // webContentsId -> Array<RequestEntry>
+const consoleMessages = new Map();  // webContentsId -> Array<ConsoleEntry>
+const networkRoutes = new Map();    // webContentsId -> Array<RouteEntry>
+const MAX_NETWORK_REQUESTS = 1000;
+const MAX_CONSOLE_MESSAGES = 500;
+
 // Browser intercept: local HTTP server + helper scripts
 let browserInterceptServer = null;
 let browserInterceptPort = 0;
@@ -59,6 +66,34 @@ function execFilePromise(command, args, options) {
       resolve({ error, stdout, stderr });
     });
   });
+}
+
+// Helper: find a network request entry by requestId (reverse search for performance)
+function findByRequestId(requests, requestId) {
+  for (let i = requests.length - 1; i >= 0; i--) {
+    if (requests[i].requestId === requestId) return requests[i];
+  }
+  return null;
+}
+
+// Helper: forward CDP debug events to the renderer for the debug panel
+function forwardDebugEvent(wcId, category, data) {
+  const wins = BrowserWindow.getAllWindows();
+  if (wins.length > 0 && !wins[0].webContents.isDestroyed()) {
+    wins[0].webContents.send('debug:cdp-event', { wcId, category, data });
+  }
+}
+
+// Helper: match URL against a glob-like pattern (supports ** and *)
+function matchUrlPattern(pattern, url) {
+  // Convert glob pattern to regex: ** matches anything, * matches non-/ characters
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const regexStr = escaped.replace(/\*\*/g, '.*').replace(/\*/g, '[^/]*');
+  try {
+    return new RegExp(regexStr).test(url);
+  } catch {
+    return false;
+  }
 }
 
 function saveSessionCookies() {
@@ -535,6 +570,9 @@ ipcMain.on('cdp:register-webview', (_, { webContentsId, panelId, url, title }) =
 ipcMain.on('cdp:unregister-webview', (_, { webContentsId }) => {
   webviewPanelMap.delete(webContentsId);
   attachedDebuggers.delete(webContentsId);
+  networkRequests.delete(webContentsId);
+  consoleMessages.delete(webContentsId);
+  networkRoutes.delete(webContentsId);
   debugLog('[CDP] Unregistered webview wcId:', webContentsId);
 });
 
@@ -544,6 +582,29 @@ ipcMain.on('cdp:update-webview', (_, { webContentsId, url, title }) => {
     if (url !== undefined) info.url = url;
     if (title !== undefined) info.title = title;
   }
+});
+
+// Debug panel IPC: direct access to buffers (no HTTP roundtrip needed from renderer)
+ipcMain.handle('debug:getNetworkRequests', (_, { wcId }) => {
+  return networkRequests.get(wcId) || [];
+});
+ipcMain.handle('debug:getConsoleMessages', (_, { wcId }) => {
+  return consoleMessages.get(wcId) || [];
+});
+ipcMain.handle('debug:clearNetwork', (_, { wcId }) => {
+  if (networkRequests.has(wcId)) networkRequests.set(wcId, []);
+  return { ok: true };
+});
+ipcMain.handle('debug:clearConsole', (_, { wcId }) => {
+  if (consoleMessages.has(wcId)) consoleMessages.set(wcId, []);
+  return { ok: true };
+});
+ipcMain.handle('debug:listPanels', () => {
+  const panels = [];
+  for (const [wcId, info] of webviewPanelMap) {
+    panels.push({ webContentsId: wcId, panelId: info.panelId, url: info.url, title: info.title });
+  }
+  return panels;
 });
 
 function setupBrowserHelperScripts() {
@@ -703,6 +764,155 @@ function startBrowserInterceptServer() {
               await wc.debugger.sendCommand('Accessibility.enable');
               await wc.debugger.sendCommand('Network.enable');
               await wc.debugger.sendCommand('Runtime.enable');
+
+              // Initialize debugging buffers
+              if (!networkRequests.has(wcId)) networkRequests.set(wcId, []);
+              if (!consoleMessages.has(wcId)) consoleMessages.set(wcId, []);
+
+              // Enable Fetch domain if routes are already configured
+              const existingRoutes = networkRoutes.get(wcId);
+              if (existingRoutes && existingRoutes.length > 0) {
+                const patterns = existingRoutes.map(r => ({ urlPattern: r.pattern }));
+                await wc.debugger.sendCommand('Fetch.enable', { patterns });
+              }
+
+              // Listen for CDP events (Network, Runtime, Fetch)
+              wc.debugger.on('message', (event, method, params) => {
+                // --- Network request tracking ---
+                if (method === 'Network.requestWillBeSent') {
+                  const requests = networkRequests.get(wcId);
+                  if (requests) {
+                    if (requests.length >= MAX_NETWORK_REQUESTS) requests.shift();
+                    requests.push({
+                      requestId: params.requestId,
+                      url: params.request.url,
+                      method: params.request.method,
+                      resourceType: params.type || 'Other',
+                      requestHeaders: params.request.headers || null,
+                      postData: params.request.postData || null,
+                      status: null,
+                      statusText: null,
+                      responseHeaders: null,
+                      encodedDataLength: null,
+                      timestamp: params.timestamp,
+                      failed: false,
+                      errorText: null,
+                      canceled: false,
+                      finished: false,
+                    });
+                    forwardDebugEvent(wcId, 'network', { type: 'request', requestId: params.requestId, url: params.request.url, method: params.request.method, resourceType: params.type || 'Other' });
+                  }
+                }
+                else if (method === 'Network.responseReceived') {
+                  const requests = networkRequests.get(wcId);
+                  if (requests) {
+                    const entry = findByRequestId(requests, params.requestId);
+                    if (entry) {
+                      entry.status = params.response.status;
+                      entry.statusText = params.response.statusText;
+                      entry.responseHeaders = params.response.headers || null;
+                      forwardDebugEvent(wcId, 'network', { type: 'response', requestId: params.requestId, status: params.response.status, statusText: params.response.statusText });
+                    }
+                  }
+                }
+                else if (method === 'Network.loadingFinished') {
+                  const requests = networkRequests.get(wcId);
+                  if (requests) {
+                    const entry = findByRequestId(requests, params.requestId);
+                    if (entry) {
+                      entry.finished = true;
+                      entry.encodedDataLength = params.encodedDataLength || 0;
+                    }
+                  }
+                }
+                else if (method === 'Network.loadingFailed') {
+                  const requests = networkRequests.get(wcId);
+                  if (requests) {
+                    const entry = findByRequestId(requests, params.requestId);
+                    if (entry) {
+                      entry.failed = true;
+                      entry.errorText = params.errorText || 'Unknown error';
+                      entry.canceled = !!params.canceled;
+                      entry.finished = true;
+                      forwardDebugEvent(wcId, 'network', { type: 'failed', requestId: params.requestId, errorText: entry.errorText });
+                    }
+                  }
+                }
+
+                // --- Console message tracking ---
+                else if (method === 'Runtime.consoleAPICalled') {
+                  const messages = consoleMessages.get(wcId);
+                  if (messages) {
+                    if (messages.length >= MAX_CONSOLE_MESSAGES) messages.shift();
+                    const text = (params.args || []).map(a => {
+                      if (a.type === 'string') return a.value;
+                      if (a.value !== undefined) return String(a.value);
+                      if (a.description) return a.description;
+                      return a.type;
+                    }).join(' ');
+                    const entry = {
+                      level: params.type || 'log',
+                      text,
+                      timestamp: params.timestamp,
+                      url: params.stackTrace?.callFrames?.[0]?.url || null,
+                      lineNumber: params.stackTrace?.callFrames?.[0]?.lineNumber || null,
+                    };
+                    messages.push(entry);
+                    forwardDebugEvent(wcId, 'console', entry);
+                  }
+                }
+                else if (method === 'Runtime.exceptionThrown') {
+                  const messages = consoleMessages.get(wcId);
+                  if (messages) {
+                    if (messages.length >= MAX_CONSOLE_MESSAGES) messages.shift();
+                    const ex = params.exceptionDetails;
+                    const text = ex?.exception?.description || ex?.text || 'Unknown exception';
+                    const entry = {
+                      level: 'error',
+                      text,
+                      timestamp: params.timestamp,
+                      url: ex?.url || null,
+                      lineNumber: ex?.lineNumber || null,
+                    };
+                    messages.push(entry);
+                    forwardDebugEvent(wcId, 'console', entry);
+                  }
+                }
+
+                // --- Fetch interception for routing ---
+                else if (method === 'Fetch.requestPaused') {
+                  const routes = networkRoutes.get(wcId);
+                  if (routes && routes.length > 0) {
+                    const matchedRoute = routes.find(r => matchUrlPattern(r.pattern, params.request.url));
+                    if (matchedRoute) {
+                      const responseHeaders = [];
+                      if (matchedRoute.contentType) {
+                        responseHeaders.push({ name: 'Content-Type', value: matchedRoute.contentType });
+                      }
+                      if (matchedRoute.headers) {
+                        for (const h of matchedRoute.headers) {
+                          const idx = h.indexOf(':');
+                          if (idx > 0) responseHeaders.push({ name: h.slice(0, idx).trim(), value: h.slice(idx + 1).trim() });
+                        }
+                      }
+                      const body = matchedRoute.body ? Buffer.from(matchedRoute.body).toString('base64') : '';
+                      wc.debugger.sendCommand('Fetch.fulfillRequest', {
+                        requestId: params.requestId,
+                        responseCode: matchedRoute.status || 200,
+                        responseHeaders,
+                        body,
+                      }).catch(e => debugLog('[CDP] Fetch.fulfillRequest error:', e.message));
+                    } else {
+                      wc.debugger.sendCommand('Fetch.continueRequest', { requestId: params.requestId })
+                        .catch(e => debugLog('[CDP] Fetch.continueRequest error:', e.message));
+                    }
+                  } else {
+                    wc.debugger.sendCommand('Fetch.continueRequest', { requestId: params.requestId })
+                      .catch(e => debugLog('[CDP] Fetch.continueRequest error:', e.message));
+                  }
+                }
+              });
+
               debugLog('[CDP] Attached debugger to wcId:', wcId);
             } catch (e) {
               debugLog('[CDP] Attach error:', e.message);
@@ -732,9 +942,118 @@ function startBrowserInterceptServer() {
           if (wc && !wc.isDestroyed() && attachedDebuggers.has(wcId)) {
             try { wc.debugger.detach(); } catch (e) {}
             attachedDebuggers.delete(wcId);
+            networkRequests.delete(wcId);
+            consoleMessages.delete(wcId);
+            networkRoutes.delete(wcId);
           }
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+
+        // --- /cdp/network-requests: get captured network requests ---
+        if (parsedUrl.pathname === '/cdp/network-requests' && req.method === 'POST') {
+          const body = await readJsonBody(req);
+          const { webContentsId: wcId } = body;
+          const requests = networkRequests.get(wcId) || [];
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ requests }));
+          return;
+        }
+
+        // --- /cdp/network-clear: clear captured network requests ---
+        if (parsedUrl.pathname === '/cdp/network-clear' && req.method === 'POST') {
+          const body = await readJsonBody(req);
+          const { webContentsId: wcId } = body;
+          if (networkRequests.has(wcId)) networkRequests.set(wcId, []);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+
+        // --- /cdp/console-messages: get captured console messages ---
+        if (parsedUrl.pathname === '/cdp/console-messages' && req.method === 'POST') {
+          const body = await readJsonBody(req);
+          const { webContentsId: wcId } = body;
+          const messages = consoleMessages.get(wcId) || [];
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ messages }));
+          return;
+        }
+
+        // --- /cdp/console-clear: clear captured console messages ---
+        if (parsedUrl.pathname === '/cdp/console-clear' && req.method === 'POST') {
+          const body = await readJsonBody(req);
+          const { webContentsId: wcId } = body;
+          if (consoleMessages.has(wcId)) consoleMessages.set(wcId, []);
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+
+        // --- /cdp/route-add: add a network route for interception ---
+        if (parsedUrl.pathname === '/cdp/route-add' && req.method === 'POST') {
+          const body = await readJsonBody(req);
+          const { webContentsId: wcId, route } = body;
+          if (!networkRoutes.has(wcId)) networkRoutes.set(wcId, []);
+          const routes = networkRoutes.get(wcId);
+          // Remove existing route with same pattern
+          const existing = routes.findIndex(r => r.pattern === route.pattern);
+          if (existing >= 0) routes.splice(existing, 1);
+          routes.push(route);
+          // Enable Fetch domain with all active patterns
+          const wc = webContents.fromId(wcId);
+          if (wc && !wc.isDestroyed() && attachedDebuggers.has(wcId)) {
+            try {
+              const patterns = routes.map(r => ({ urlPattern: r.pattern }));
+              await wc.debugger.sendCommand('Fetch.enable', { patterns });
+            } catch (e) {
+              debugLog('[CDP] Fetch.enable error:', e.message);
+            }
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, count: routes.length }));
+          return;
+        }
+
+        // --- /cdp/route-remove: remove a network route ---
+        if (parsedUrl.pathname === '/cdp/route-remove' && req.method === 'POST') {
+          const body = await readJsonBody(req);
+          const { webContentsId: wcId, pattern } = body;
+          const routes = networkRoutes.get(wcId);
+          if (routes) {
+            if (pattern) {
+              const idx = routes.findIndex(r => r.pattern === pattern);
+              if (idx >= 0) routes.splice(idx, 1);
+            } else {
+              routes.length = 0; // Remove all
+            }
+            const wc = webContents.fromId(wcId);
+            if (wc && !wc.isDestroyed() && attachedDebuggers.has(wcId)) {
+              try {
+                if (routes.length > 0) {
+                  const patterns = routes.map(r => ({ urlPattern: r.pattern }));
+                  await wc.debugger.sendCommand('Fetch.enable', { patterns });
+                } else {
+                  await wc.debugger.sendCommand('Fetch.disable');
+                }
+              } catch (e) {
+                debugLog('[CDP] Fetch toggle error:', e.message);
+              }
+            }
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, count: routes ? routes.length : 0 }));
+          return;
+        }
+
+        // --- /cdp/route-list: list active routes ---
+        if (parsedUrl.pathname === '/cdp/route-list' && req.method === 'POST') {
+          const body = await readJsonBody(req);
+          const { webContentsId: wcId } = body;
+          const routes = networkRoutes.get(wcId) || [];
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ routes }));
           return;
         }
 
@@ -1078,6 +1397,9 @@ app.whenReady().then(async () => {
       contents.once('destroyed', () => {
         attachedDebuggers.delete(contents.id);
         webviewPanelMap.delete(contents.id);
+        networkRequests.delete(contents.id);
+        consoleMessages.delete(contents.id);
+        networkRoutes.delete(contents.id);
       });
     }
   });

--- a/mcp-server/cdp-client.js
+++ b/mcp-server/cdp-client.js
@@ -22,6 +22,34 @@ export class CdpClient {
     return this._post('/open-panel', { url, termId, profileId, groupId });
   }
 
+  async getNetworkRequests(webContentsId) {
+    return this._post('/cdp/network-requests', { webContentsId });
+  }
+
+  async clearNetworkRequests(webContentsId) {
+    return this._post('/cdp/network-clear', { webContentsId });
+  }
+
+  async getConsoleMessages(webContentsId) {
+    return this._post('/cdp/console-messages', { webContentsId });
+  }
+
+  async clearConsoleMessages(webContentsId) {
+    return this._post('/cdp/console-clear', { webContentsId });
+  }
+
+  async addRoute(webContentsId, route) {
+    return this._post('/cdp/route-add', { webContentsId, route });
+  }
+
+  async removeRoute(webContentsId, pattern) {
+    return this._post('/cdp/route-remove', { webContentsId, pattern });
+  }
+
+  async listRoutes(webContentsId) {
+    return this._post('/cdp/route-list', { webContentsId });
+  }
+
   _get(path) {
     return new Promise((resolve, reject) => {
       const url = `http://127.0.0.1:${this.port}${path}?token=${this.token}`;

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -445,6 +445,178 @@ server.tool('set_network_conditions', 'Emulate network conditions', {
   });
 });
 
+// --- Debugging tools ---
+
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+server.tool('network_requests', 'List captured network requests for debugging (XHR, fetch, document loads, failures, etc.)', {
+  filter: z.string().optional().describe('Regex to filter URLs (e.g. "/api/" or "\\.json$")'),
+  static: z.boolean().optional().describe('Include successful static resources like images, fonts, CSS, JS (default: false)'),
+  requestHeaders: z.boolean().optional().describe('Include request headers in output'),
+  requestBody: z.boolean().optional().describe('Include request body/postData in output'),
+}, async ({ filter, static: includeStatic, requestHeaders: showReqHeaders, requestBody: showReqBody }) => {
+  return withMutex(async () => {
+    const wcId = requirePanel();
+    const resp = await cdp.getNetworkRequests(wcId);
+    let requests = resp.requests || [];
+
+    // Filter out successful static resources by default
+    const staticTypes = new Set(['Image', 'Font', 'Stylesheet', 'Script']);
+    if (!includeStatic) {
+      requests = requests.filter(r => {
+        if (staticTypes.has(r.resourceType) && r.status && r.status >= 200 && r.status < 400) return false;
+        return true;
+      });
+    }
+
+    // Apply URL regex filter
+    if (filter) {
+      const regex = new RegExp(filter);
+      requests = requests.filter(r => regex.test(r.url));
+    }
+
+    if (requests.length === 0) {
+      return { content: [{ type: 'text', text: 'No network requests captured.' }] };
+    }
+
+    const lines = requests.map(r => {
+      const parts = [];
+      if (r.failed) parts.push('FAILED');
+      else if (r.status) parts.push(String(r.status));
+      else parts.push('PENDING');
+      parts.push(`${r.method} ${r.url}`);
+      parts.push(`[${r.resourceType}]`);
+      if (r.encodedDataLength != null) parts.push(formatBytes(r.encodedDataLength));
+      if (r.failed && r.errorText) parts.push(`Error: ${r.errorText}${r.canceled ? ' (canceled)' : ''}`);
+
+      let line = parts.join('  ');
+      if (showReqHeaders && r.requestHeaders) {
+        line += '\n  Request Headers: ' + JSON.stringify(r.requestHeaders);
+      }
+      if (showReqBody && r.postData) {
+        const body = r.postData.length > 500 ? r.postData.slice(0, 500) + '...' : r.postData;
+        line += '\n  Request Body: ' + body;
+      }
+      return line;
+    });
+
+    return { content: [{ type: 'text', text: `${requests.length} request(s) captured:\n\n${lines.join('\n')}` }] };
+  });
+});
+
+server.tool('network_clear', 'Clear the captured network requests buffer', {}, async () => {
+  return withMutex(async () => {
+    const wcId = requirePanel();
+    await cdp.clearNetworkRequests(wcId);
+    return { content: [{ type: 'text', text: 'Network request buffer cleared.' }] };
+  });
+});
+
+const consoleLevels = ['error', 'warning', 'info', 'debug'];
+
+server.tool('console_messages', 'Get console output from the page (log, warn, error, etc.)', {
+  level: z.enum(['error', 'warning', 'info', 'debug']).optional().describe('Minimum level to include (default: info). Each level includes more severe levels.'),
+  clear: z.boolean().optional().describe('Clear the buffer after reading'),
+}, async ({ level, clear }) => {
+  return withMutex(async () => {
+    const wcId = requirePanel();
+    const resp = await cdp.getConsoleMessages(wcId);
+    let messages = resp.messages || [];
+
+    // Map console API types to severity levels
+    const typeToLevel = {
+      error: 'error',
+      warning: 'warning', warn: 'warning',
+      info: 'info', log: 'info',
+      debug: 'debug', trace: 'debug', dir: 'debug', table: 'debug',
+    };
+
+    const minLevel = level || 'info';
+    const minIdx = consoleLevels.indexOf(minLevel);
+    messages = messages.filter(m => {
+      const msgLevel = typeToLevel[m.level] || 'info';
+      return consoleLevels.indexOf(msgLevel) <= minIdx;
+    });
+
+    if (clear) await cdp.clearConsoleMessages(wcId);
+
+    if (messages.length === 0) {
+      return { content: [{ type: 'text', text: 'No console messages captured.' }] };
+    }
+
+    const lines = messages.map(m => {
+      const levelTag = (typeToLevel[m.level] || m.level).toUpperCase();
+      let line = `[${levelTag}] ${m.text}`;
+      if (m.url) line += `  (${m.url}${m.lineNumber != null ? ':' + m.lineNumber : ''})`;
+      return line;
+    });
+
+    return { content: [{ type: 'text', text: `${messages.length} message(s):\n\n${lines.join('\n')}` }] };
+  });
+});
+
+server.tool('console_clear', 'Clear the captured console messages buffer', {}, async () => {
+  return withMutex(async () => {
+    const wcId = requirePanel();
+    await cdp.clearConsoleMessages(wcId);
+    return { content: [{ type: 'text', text: 'Console message buffer cleared.' }] };
+  });
+});
+
+server.tool('evaluate', 'Evaluate a JavaScript expression on the page and return the result', {
+  expression: z.string().describe('JavaScript expression to evaluate (e.g. "document.title", "JSON.stringify(performance.timing)")'),
+}, async ({ expression }) => {
+  return withMutex(async () => {
+    const wcId = requirePanel();
+    const resp = await cdp.sendCommand(wcId, 'Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+    });
+    if (resp.error) throw new Error(resp.error);
+    const { result, exceptionDetails } = resp.result;
+    if (exceptionDetails) {
+      const errMsg = exceptionDetails.exception?.description || exceptionDetails.text || 'Evaluation error';
+      return { content: [{ type: 'text', text: `Error: ${errMsg}` }] };
+    }
+    const value = result.value !== undefined ? JSON.stringify(result.value, null, 2) : result.description || result.type;
+    return { content: [{ type: 'text', text: value }] };
+  });
+});
+
+server.tool('route', 'Mock/intercept network requests matching a URL pattern', {
+  pattern: z.string().describe('URL pattern to match (e.g. "**/api/users", "**/*.json")'),
+  status: z.number().optional().describe('HTTP status code to return (default: 200)'),
+  body: z.string().optional().describe('Response body (text or JSON string)'),
+  contentType: z.string().optional().describe('Content-Type header (e.g. "application/json")'),
+  headers: z.array(z.string()).optional().describe('Headers to add in "Name: Value" format'),
+  removeHeaders: z.string().optional().describe('Comma-separated list of header names to remove from request'),
+}, async ({ pattern, status, body, contentType, headers, removeHeaders }) => {
+  return withMutex(async () => {
+    const wcId = requirePanel();
+    const route = { pattern, status: status || 200, body: body || '', contentType: contentType || null, headers: headers || [], removeHeaders: removeHeaders || null };
+    const resp = await cdp.addRoute(wcId, route);
+    if (resp.error) throw new Error(resp.error);
+    return { content: [{ type: 'text', text: `Route added: ${pattern} → ${route.status}${body ? ` (${body.length} bytes)` : ''}\n${resp.count} active route(s)` }] };
+  });
+});
+
+server.tool('unroute', 'Remove network routes (all routes if no pattern specified)', {
+  pattern: z.string().optional().describe('URL pattern to remove (omit to remove all routes)'),
+}, async ({ pattern }) => {
+  return withMutex(async () => {
+    const wcId = requirePanel();
+    const resp = await cdp.removeRoute(wcId, pattern || null);
+    if (resp.error) throw new Error(resp.error);
+    return { content: [{ type: 'text', text: pattern ? `Removed route: ${pattern}` : 'All routes removed.' }] };
+  });
+});
+
 // --- Start server ---
 
 const transport = new StdioServerTransport();

--- a/preload.js
+++ b/preload.js
@@ -102,6 +102,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
   panelCreateResponse: (requestId, panelId, error) =>
     ipcRenderer.send('panel:create-response', { requestId, panelId, error }),
 
+  // Debug panel
+  onDebugCdpEvent: (callback) => {
+    const listener = (_, data) => callback(data);
+    ipcRenderer.on('debug:cdp-event', listener);
+    return () => ipcRenderer.removeListener('debug:cdp-event', listener);
+  },
+  debugGetNetworkRequests: (wcId) => ipcRenderer.invoke('debug:getNetworkRequests', { wcId }),
+  debugGetConsoleMessages: (wcId) => ipcRenderer.invoke('debug:getConsoleMessages', { wcId }),
+  debugClearNetwork: (wcId) => ipcRenderer.invoke('debug:clearNetwork', { wcId }),
+  debugClearConsole: (wcId) => ipcRenderer.invoke('debug:clearConsole', { wcId }),
+  debugListPanels: () => ipcRenderer.invoke('debug:listPanels'),
+
   // CDP webview registration
   cdpRegisterWebview: (webContentsId, panelId, url) =>
     ipcRenderer.send('cdp:register-webview', { webContentsId, panelId, url }),

--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -3,18 +3,21 @@
 const DEFAULT_WEB_WIDTH = 750;
 const DEFAULT_TERM_WIDTH = 620;
 const DEFAULT_FILE_WIDTH = 900;
+const DEFAULT_DEBUG_WIDTH = 600;
 
 const MAX_TERMINAL_PANELS = 20;
 const MAX_WEB_PANELS = 20;
 const MAX_FILE_PANELS = 10;
+const MAX_DEBUG_PANELS = 5;
 
 function getProfileMaxPanels(profile) {
-  const defaults = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
+  const defaults = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS, debug: MAX_DEBUG_PANELS };
   if (!profile || !profile.maxPanels) return defaults;
   return {
     terminal: profile.maxPanels.terminal ?? defaults.terminal,
     web: profile.maxPanels.web ?? defaults.web,
     file: profile.maxPanels.file ?? defaults.file,
+    debug: profile.maxPanels.debug ?? defaults.debug,
   };
 }
 
@@ -146,7 +149,7 @@ async function init() {
         templates: [],
         urlHistory: [],
         bookmarks: [],
-        maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS },
+        maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS, debug: MAX_DEBUG_PANELS },
       }],
     };
   }
@@ -320,6 +323,10 @@ function killGroupTerminals(group) {
       const { cleanup } = activeWebPanels.get(p.id);
       if (cleanup) cleanup();
     }
+    if (p.type === 'debug' && activeDebugPanels.has(p.id)) {
+      const { cleanup } = activeDebugPanels.get(p.id);
+      if (cleanup) cleanup();
+    }
   });
 }
 
@@ -348,7 +355,7 @@ async function addPanel(type) {
     extraProps = { rootDir: result.path, openFile: null, openFiles: [] };
   }
 
-  const widths = { terminal: DEFAULT_TERM_WIDTH, web: DEFAULT_WEB_WIDTH, file: DEFAULT_FILE_WIDTH };
+  const widths = { terminal: DEFAULT_TERM_WIDTH, web: DEFAULT_WEB_WIDTH, file: DEFAULT_FILE_WIDTH, debug: DEFAULT_DEBUG_WIDTH };
   const panel = {
     id: generateId(),
     type,
@@ -495,6 +502,10 @@ function removePanel(panelId) {
   }
   if (activeWebPanels.has(panelId)) {
     const { cleanup } = activeWebPanels.get(panelId);
+    if (cleanup) cleanup();
+  }
+  if (activeDebugPanels.has(panelId)) {
+    const { cleanup } = activeDebugPanels.get(panelId);
     if (cleanup) cleanup();
   }
 
@@ -756,6 +767,7 @@ function teardownCurrentProfile() {
   activeTerminals.clear();
   activeEditors.clear();
   activeWebPanels.clear();
+  activeDebugPanels.clear();
   activeLspServers.clear();
 
   // Destroy all panel searches
@@ -784,7 +796,7 @@ function addProfile(name) {
     templates: [],
     urlHistory: [],
     bookmarks: [],
-    maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS },
+    maxPanels: { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS, debug: MAX_DEBUG_PANELS },
   };
 
   teardownCurrentProfile();

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -39,6 +39,7 @@
   <script src="modals/lsp-settings-modal.js"></script>
   <script src="modals/auth-modal.js"></script>
   <script src="modals/panel-limit-modal.js"></script>
+  <script src="panels/debug-panel.js"></script>
   <script src="panels/file-panel.js"></script>
   <script src="panels/panel-drag.js"></script>
 </body>

--- a/renderer/modals/panel-settings-modal.js
+++ b/renderer/modals/panel-settings-modal.js
@@ -49,7 +49,7 @@ function showPanelSettingsModal(panel) {
   // Header
   const header = document.createElement('div');
   header.className = 'modal-header';
-  const typeNames = { terminal: 'Terminal', web: 'Web', file: 'File' };
+  const typeNames = { terminal: 'Terminal', web: 'Web', file: 'File', debug: 'Debug' };
   header.textContent = (typeNames[panel.type] || 'Panel') + ' Settings';
   container.appendChild(header);
 

--- a/renderer/modals/profile-settings-modal.js
+++ b/renderer/modals/profile-settings-modal.js
@@ -22,6 +22,7 @@ function showProfileSettingsModal(profile) {
     { key: 'terminal', label: 'Max Terminal Panels' },
     { key: 'web', label: 'Max Web Panels' },
     { key: 'file', label: 'Max File Panels' },
+    { key: 'debug', label: 'Max Debug Panels' },
   ];
 
   const inputs = {};

--- a/renderer/panels/debug-panel.js
+++ b/renderer/panels/debug-panel.js
@@ -1,0 +1,416 @@
+// debug-panel.js - Debug panel for viewing network requests and console messages
+
+// Map<panelId, { cleanup, remount }>
+const activeDebugPanels = new Map();
+
+function renderDebugPanel(panel, container) {
+  const layout = document.createElement('div');
+  layout.className = 'debug-panel-layout';
+
+  // Toolbar: panel selector + tabs
+  const toolbar = document.createElement('div');
+  toolbar.className = 'debug-toolbar';
+
+  const panelSelect = document.createElement('select');
+  panelSelect.className = 'debug-panel-select';
+  panelSelect.title = 'Select web panel to monitor';
+
+  const tabs = document.createElement('div');
+  tabs.className = 'debug-tabs';
+
+  const networkTab = document.createElement('button');
+  networkTab.className = 'debug-tab active';
+  networkTab.textContent = 'Network';
+  networkTab.dataset.tab = 'network';
+
+  const consoleTab = document.createElement('button');
+  consoleTab.className = 'debug-tab';
+  consoleTab.textContent = 'Console';
+  consoleTab.dataset.tab = 'console';
+
+  tabs.appendChild(networkTab);
+  tabs.appendChild(consoleTab);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.className = 'debug-clear-btn';
+  clearBtn.textContent = 'Clear';
+  clearBtn.title = 'Clear current tab data';
+
+  toolbar.appendChild(panelSelect);
+  toolbar.appendChild(tabs);
+  toolbar.appendChild(clearBtn);
+  layout.appendChild(toolbar);
+
+  // Filter bar
+  const filterBar = document.createElement('div');
+  filterBar.className = 'debug-filter-bar';
+
+  const filterInput = document.createElement('input');
+  filterInput.className = 'debug-filter-input';
+  filterInput.type = 'text';
+  filterInput.placeholder = 'Filter by URL or text...';
+
+  const levelFilter = document.createElement('div');
+  levelFilter.className = 'debug-level-filter';
+  levelFilter.style.display = 'none'; // Shown only in console tab
+
+  ['error', 'warning', 'info', 'debug'].forEach(level => {
+    const btn = document.createElement('button');
+    btn.className = 'debug-level-btn active';
+    btn.dataset.level = level;
+    btn.textContent = level.charAt(0).toUpperCase() + level.slice(1);
+    levelFilter.appendChild(btn);
+  });
+
+  filterBar.appendChild(filterInput);
+  filterBar.appendChild(levelFilter);
+  layout.appendChild(filterBar);
+
+  // Content areas
+  const networkContent = document.createElement('div');
+  networkContent.className = 'debug-content debug-network-content';
+
+  const consoleContent = document.createElement('div');
+  consoleContent.className = 'debug-content debug-console-content';
+  consoleContent.style.display = 'none';
+
+  layout.appendChild(networkContent);
+  layout.appendChild(consoleContent);
+
+  // Stats bar
+  const statsBar = document.createElement('div');
+  statsBar.className = 'debug-stats-bar';
+  statsBar.textContent = 'No panel selected';
+  layout.appendChild(statsBar);
+
+  container.appendChild(layout);
+
+  mountDebugPanel(panel, {
+    panelSelect, networkTab, consoleTab, clearBtn,
+    filterInput, levelFilter, networkContent, consoleContent, statsBar,
+  });
+}
+
+async function mountDebugPanel(panel, ui) {
+  if (activeDebugPanels.has(panel.id)) {
+    // Already mounted — just refresh
+    return;
+  }
+
+  let activeTab = 'network';
+  let monitoredWcId = null;
+  let networkData = [];
+  let consoleData = [];
+  let activeLevels = new Set(['error', 'warning', 'info', 'debug']);
+  let filterText = '';
+
+  // Load panel list
+  async function refreshPanelList() {
+    try {
+      const panels = await window.electronAPI.debugListPanels();
+      ui.panelSelect.innerHTML = '';
+      const emptyOpt = document.createElement('option');
+      emptyOpt.value = '';
+      emptyOpt.textContent = '-- Select panel --';
+      ui.panelSelect.appendChild(emptyOpt);
+      for (const p of panels) {
+        const opt = document.createElement('option');
+        opt.value = String(p.webContentsId);
+        opt.textContent = `${p.title || p.url || p.panelId} (${p.panelId})`;
+        ui.panelSelect.appendChild(opt);
+      }
+      if (monitoredWcId) ui.panelSelect.value = String(monitoredWcId);
+    } catch (e) {
+      // Panels not available yet
+    }
+  }
+
+  await refreshPanelList();
+
+  // Refresh panel list periodically (panels come and go)
+  const panelListInterval = setInterval(refreshPanelList, 5000);
+
+  // Load data for selected panel
+  async function loadData() {
+    if (!monitoredWcId) return;
+    try {
+      const [netResp, conResp] = await Promise.all([
+        window.electronAPI.debugGetNetworkRequests(monitoredWcId),
+        window.electronAPI.debugGetConsoleMessages(monitoredWcId),
+      ]);
+      networkData = netResp || [];
+      consoleData = conResp || [];
+      renderActiveTab();
+    } catch (e) {
+      // Panel may have been destroyed
+    }
+  }
+
+  // Tab switching
+  function switchTab(tab) {
+    activeTab = tab;
+    ui.networkTab.classList.toggle('active', tab === 'network');
+    ui.consoleTab.classList.toggle('active', tab === 'console');
+    ui.networkContent.style.display = tab === 'network' ? '' : 'none';
+    ui.consoleContent.style.display = tab === 'console' ? '' : 'none';
+    ui.levelFilter.style.display = tab === 'console' ? '' : 'none';
+    renderActiveTab();
+  }
+
+  ui.networkTab.addEventListener('click', () => switchTab('network'));
+  ui.consoleTab.addEventListener('click', () => switchTab('console'));
+
+  // Panel selector
+  ui.panelSelect.addEventListener('change', () => {
+    const val = ui.panelSelect.value;
+    monitoredWcId = val ? Number(val) : null;
+    networkData = [];
+    consoleData = [];
+    renderActiveTab();
+    if (monitoredWcId) loadData();
+    updateStats();
+  });
+
+  // Clear button
+  ui.clearBtn.addEventListener('click', async () => {
+    if (!monitoredWcId) return;
+    if (activeTab === 'network') {
+      await window.electronAPI.debugClearNetwork(monitoredWcId);
+      networkData = [];
+    } else {
+      await window.electronAPI.debugClearConsole(monitoredWcId);
+      consoleData = [];
+    }
+    renderActiveTab();
+    updateStats();
+  });
+
+  // Filter input
+  ui.filterInput.addEventListener('input', () => {
+    filterText = ui.filterInput.value;
+    renderActiveTab();
+  });
+
+  // Level filter buttons
+  ui.levelFilter.querySelectorAll('.debug-level-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const level = btn.dataset.level;
+      if (activeLevels.has(level)) activeLevels.delete(level);
+      else activeLevels.add(level);
+      btn.classList.toggle('active', activeLevels.has(level));
+      renderActiveTab();
+    });
+  });
+
+  // Real-time event listener
+  const removeEventListener = window.electronAPI.onDebugCdpEvent(({ wcId, category, data }) => {
+    if (wcId !== monitoredWcId) return;
+
+    if (category === 'network') {
+      if (data.type === 'request') {
+        networkData.push({
+          requestId: data.requestId, url: data.url, method: data.method,
+          resourceType: data.resourceType, status: null, failed: false,
+          errorText: null, encodedDataLength: null,
+        });
+      } else if (data.type === 'response') {
+        const entry = networkData.findLast(r => r.requestId === data.requestId);
+        if (entry) {
+          entry.status = data.status;
+          entry.statusText = data.statusText;
+        }
+      } else if (data.type === 'failed') {
+        const entry = networkData.findLast(r => r.requestId === data.requestId);
+        if (entry) {
+          entry.failed = true;
+          entry.errorText = data.errorText;
+        }
+      }
+      if (activeTab === 'network') renderNetworkTab();
+      updateStats();
+    } else if (category === 'console') {
+      consoleData.push(data);
+      if (activeTab === 'console') renderConsoleTab();
+      updateStats();
+    }
+  });
+
+  function renderActiveTab() {
+    if (activeTab === 'network') renderNetworkTab();
+    else renderConsoleTab();
+  }
+
+  function renderNetworkTab() {
+    const container = ui.networkContent;
+    container.innerHTML = '';
+
+    if (!monitoredWcId) {
+      container.innerHTML = '<div class="debug-empty">Select a web panel to monitor</div>';
+      return;
+    }
+
+    let filtered = networkData;
+    if (filterText) {
+      try {
+        const re = new RegExp(filterText, 'i');
+        filtered = filtered.filter(r => re.test(r.url));
+      } catch {
+        filtered = filtered.filter(r => r.url.toLowerCase().includes(filterText.toLowerCase()));
+      }
+    }
+
+    if (filtered.length === 0) {
+      container.innerHTML = '<div class="debug-empty">No network requests</div>';
+      return;
+    }
+
+    // Table header
+    const header = document.createElement('div');
+    header.className = 'debug-request-row debug-request-header';
+    header.innerHTML = '<span class="dr-status">Status</span><span class="dr-method">Method</span><span class="dr-url">URL</span><span class="dr-type">Type</span><span class="dr-size">Size</span>';
+    container.appendChild(header);
+
+    for (const r of filtered) {
+      const row = document.createElement('div');
+      row.className = 'debug-request-row';
+
+      // Status color
+      let statusClass = 'dr-pending';
+      let statusText = '...';
+      if (r.failed) { statusClass = 'dr-failed'; statusText = 'FAIL'; }
+      else if (r.status) {
+        statusText = String(r.status);
+        if (r.status >= 200 && r.status < 300) statusClass = 'dr-success';
+        else if (r.status >= 300 && r.status < 400) statusClass = 'dr-redirect';
+        else if (r.status >= 400) statusClass = 'dr-error';
+      }
+
+      const size = r.encodedDataLength != null ? formatBytesUI(r.encodedDataLength) : '';
+
+      row.innerHTML = `<span class="dr-status ${statusClass}">${statusText}</span><span class="dr-method">${r.method || ''}</span><span class="dr-url" title="${escapeHtml(r.url)}">${escapeHtml(truncateUrl(r.url))}</span><span class="dr-type">${r.resourceType || ''}</span><span class="dr-size">${size}</span>`;
+
+      if (r.failed && r.errorText) {
+        const errorSpan = document.createElement('div');
+        errorSpan.className = 'dr-error-detail';
+        errorSpan.textContent = r.errorText;
+        row.appendChild(errorSpan);
+      }
+
+      container.appendChild(row);
+    }
+
+    // Auto-scroll to bottom
+    container.scrollTop = container.scrollHeight;
+  }
+
+  function renderConsoleTab() {
+    const container = ui.consoleContent;
+    container.innerHTML = '';
+
+    if (!monitoredWcId) {
+      container.innerHTML = '<div class="debug-empty">Select a web panel to monitor</div>';
+      return;
+    }
+
+    const typeToLevel = {
+      error: 'error', warning: 'warning', warn: 'warning',
+      info: 'info', log: 'info', debug: 'debug', trace: 'debug', dir: 'debug', table: 'debug',
+    };
+
+    let filtered = consoleData.filter(m => {
+      const level = typeToLevel[m.level] || 'info';
+      return activeLevels.has(level);
+    });
+
+    if (filterText) {
+      const lower = filterText.toLowerCase();
+      filtered = filtered.filter(m => m.text.toLowerCase().includes(lower));
+    }
+
+    if (filtered.length === 0) {
+      container.innerHTML = '<div class="debug-empty">No console messages</div>';
+      return;
+    }
+
+    for (const m of filtered) {
+      const level = typeToLevel[m.level] || 'info';
+      const entry = document.createElement('div');
+      entry.className = `debug-console-entry debug-level-${level}`;
+
+      const tag = document.createElement('span');
+      tag.className = 'dc-level';
+      tag.textContent = level.toUpperCase();
+      entry.appendChild(tag);
+
+      const text = document.createElement('span');
+      text.className = 'dc-text';
+      text.textContent = m.text;
+      entry.appendChild(text);
+
+      if (m.url) {
+        const source = document.createElement('span');
+        source.className = 'dc-source';
+        source.textContent = `${shortenUrl(m.url)}${m.lineNumber != null ? ':' + m.lineNumber : ''}`;
+        entry.appendChild(source);
+      }
+
+      container.appendChild(entry);
+    }
+
+    container.scrollTop = container.scrollHeight;
+  }
+
+  function updateStats() {
+    if (!monitoredWcId) {
+      ui.statsBar.textContent = 'No panel selected';
+      return;
+    }
+    const errors = networkData.filter(r => r.failed || (r.status && r.status >= 400)).length;
+    const consoleErrors = consoleData.filter(m => m.level === 'error').length;
+    ui.statsBar.textContent = `Network: ${networkData.length} requests${errors ? ` (${errors} errors)` : ''} | Console: ${consoleData.length} messages${consoleErrors ? ` (${consoleErrors} errors)` : ''}`;
+  }
+
+  updateStats();
+
+  // Helpers
+  function formatBytesUI(bytes) {
+    if (bytes === 0) return '0 B';
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+  }
+
+  function escapeHtml(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  function truncateUrl(url) {
+    if (url.length <= 80) return url;
+    try {
+      const u = new URL(url);
+      const path = u.pathname + u.search;
+      if (path.length > 60) return u.origin + path.slice(0, 57) + '...';
+      return url;
+    } catch {
+      return url.slice(0, 77) + '...';
+    }
+  }
+
+  function shortenUrl(url) {
+    try {
+      const u = new URL(url);
+      const parts = u.pathname.split('/');
+      return parts[parts.length - 1] || u.pathname;
+    } catch {
+      return url;
+    }
+  }
+
+  const cleanup = () => {
+    clearInterval(panelListInterval);
+    removeEventListener();
+    activeDebugPanels.delete(panel.id);
+  };
+
+  activeDebugPanels.set(panel.id, { cleanup });
+}

--- a/renderer/panels/panel-strip.js
+++ b/renderer/panels/panel-strip.js
@@ -76,9 +76,15 @@ function renderPanelStrip(scrollToEnd = true) {
     fileBtn.textContent = '+ Files';
     fileBtn.addEventListener('click', () => addPanel('file'));
 
+    const debugBtn = document.createElement('button');
+    debugBtn.className = 'add-panel-btn';
+    debugBtn.textContent = '+ Debug';
+    debugBtn.addEventListener('click', () => addPanel('debug'));
+
     actions.appendChild(webBtn);
     actions.appendChild(termBtn);
     actions.appendChild(fileBtn);
+    actions.appendChild(debugBtn);
     empty.appendChild(title);
     empty.appendChild(actions);
     wrapper.appendChild(empty);
@@ -106,9 +112,15 @@ function renderPanelStrip(scrollToEnd = true) {
     fileBtn.textContent = '+ Files';
     fileBtn.addEventListener('click', () => addPanel('file'));
 
+    const debugBtn2 = document.createElement('button');
+    debugBtn2.className = 'add-panel-btn';
+    debugBtn2.textContent = '+ Debug';
+    debugBtn2.addEventListener('click', () => addPanel('debug'));
+
     addControls.appendChild(webBtn);
     addControls.appendChild(termBtn);
     addControls.appendChild(fileBtn);
+    addControls.appendChild(debugBtn2);
     wrapper.appendChild(addControls);
   }
 
@@ -136,7 +148,7 @@ function createPanelElement(panel) {
 
   const typeLabel = document.createElement('span');
   typeLabel.className = 'panel-type-label';
-  typeLabel.textContent = panel.type === 'web' ? 'Web' : panel.type === 'file' ? 'Files' : 'Terminal';
+  typeLabel.textContent = panel.type === 'web' ? 'Web' : panel.type === 'file' ? 'Files' : panel.type === 'debug' ? 'Debug' : 'Terminal';
 
   const settingsBtn = document.createElement('button');
   settingsBtn.className = 'panel-settings-btn';
@@ -164,6 +176,8 @@ function createPanelElement(panel) {
     renderWebPanel(panel, content);
   } else if (panel.type === 'file') {
     renderFilePanel(panel, content);
+  } else if (panel.type === 'debug') {
+    renderDebugPanel(panel, content);
   } else {
     renderTermPanel(panel, content);
   }

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1717,3 +1717,252 @@ webview.webview-hidden {
   background: #2a2a4e;
   border-color: #887040;
 }
+
+/* ── Debug Panel ─────────────────────────────────── */
+
+.debug-panel-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #0d0d0d;
+  color: #d4d4d4;
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+  font-size: 12px;
+}
+
+.debug-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: #1a1a2e;
+  border-bottom: 1px solid #2a2a4e;
+  flex-shrink: 0;
+}
+
+.debug-panel-select {
+  background: #16213e;
+  color: #d4d4d4;
+  border: 1px solid #2a2a4e;
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: 11px;
+  max-width: 200px;
+  flex-shrink: 1;
+}
+
+.debug-tabs {
+  display: flex;
+  gap: 2px;
+}
+
+.debug-tab {
+  background: transparent;
+  color: #888;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 4px 10px;
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.debug-tab:hover {
+  color: #ccc;
+}
+
+.debug-tab.active {
+  color: #e0e0e0;
+  border-bottom-color: #533483;
+}
+
+.debug-clear-btn {
+  margin-left: auto;
+  background: transparent;
+  color: #888;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.debug-clear-btn:hover {
+  color: #ccc;
+  border-color: #555;
+}
+
+.debug-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: #111;
+  border-bottom: 1px solid #222;
+  flex-shrink: 0;
+}
+
+.debug-filter-input {
+  flex: 1;
+  background: #1a1a2e;
+  color: #d4d4d4;
+  border: 1px solid #2a2a4e;
+  border-radius: 3px;
+  padding: 3px 6px;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.debug-filter-input::placeholder {
+  color: #555;
+}
+
+.debug-level-filter {
+  display: flex;
+  gap: 2px;
+}
+
+.debug-level-btn {
+  background: transparent;
+  color: #555;
+  border: 1px solid #333;
+  border-radius: 3px;
+  padding: 1px 6px;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.debug-level-btn.active {
+  color: #ccc;
+  border-color: #555;
+}
+
+.debug-level-btn[data-level="error"].active { color: #ff6b6b; border-color: #663333; }
+.debug-level-btn[data-level="warning"].active { color: #f1c40f; border-color: #665e20; }
+.debug-level-btn[data-level="info"].active { color: #8be9fd; border-color: #2a5a66; }
+.debug-level-btn[data-level="debug"].active { color: #888; border-color: #444; }
+
+.debug-content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.debug-empty {
+  text-align: center;
+  color: #555;
+  padding: 40px 0;
+  font-size: 12px;
+}
+
+/* Network requests table */
+
+.debug-request-row {
+  display: flex;
+  align-items: baseline;
+  padding: 2px 8px;
+  border-bottom: 1px solid #1a1a1a;
+  gap: 8px;
+  min-height: 20px;
+}
+
+.debug-request-row:hover {
+  background: #1a1a2e;
+}
+
+.debug-request-header {
+  background: #111;
+  color: #888;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.debug-request-header:hover {
+  background: #111;
+}
+
+.dr-status { width: 45px; flex-shrink: 0; font-weight: 600; }
+.dr-method { width: 45px; flex-shrink: 0; color: #888; }
+.dr-url { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dr-type { width: 60px; flex-shrink: 0; color: #666; font-size: 10px; }
+.dr-size { width: 55px; flex-shrink: 0; color: #666; text-align: right; font-size: 10px; }
+
+.dr-pending { color: #888; }
+.dr-success { color: #50fa7b; }
+.dr-redirect { color: #f1fa8c; }
+.dr-error { color: #ff6b6b; }
+.dr-failed { color: #ff5555; }
+
+.dr-error-detail {
+  width: 100%;
+  color: #ff5555;
+  font-size: 10px;
+  padding: 1px 0 1px 98px;
+}
+
+/* Console messages */
+
+.debug-console-entry {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 2px 8px;
+  border-bottom: 1px solid #1a1a1a;
+  min-height: 18px;
+}
+
+.debug-console-entry:hover {
+  background: #1a1a2e;
+}
+
+.dc-level {
+  width: 55px;
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.dc-text {
+  flex: 1;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.dc-source {
+  flex-shrink: 0;
+  color: #555;
+  font-size: 10px;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.debug-level-error { border-left: 2px solid #ff5555; }
+.debug-level-error .dc-level { color: #ff6b6b; }
+.debug-level-error .dc-text { color: #ff8888; }
+
+.debug-level-warning { border-left: 2px solid #f1c40f; }
+.debug-level-warning .dc-level { color: #f1c40f; }
+.debug-level-warning .dc-text { color: #f5d060; }
+
+.debug-level-info .dc-level { color: #8be9fd; }
+.debug-level-info .dc-text { color: #d4d4d4; }
+
+.debug-level-debug .dc-level { color: #666; }
+.debug-level-debug .dc-text { color: #888; }
+
+/* Stats bar */
+
+.debug-stats-bar {
+  padding: 3px 8px;
+  background: #1a1a2e;
+  border-top: 1px solid #2a2a4e;
+  color: #666;
+  font-size: 10px;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
Add 7 new MCP tools: network_requests, network_clear, console_messages, console_clear, evaluate, route, unroute. Capture CDP Network and Runtime events in main.js with in-memory buffers. Add network route mocking via Fetch domain. Add real-time debug panel with network/console tabs, panel selector, filtering, and color-coded output.

Closes #115