### PR TITLE
feat: Auto-suspend inactive web panels to save resources

### DIFF
--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -23,6 +23,11 @@ function getProfileInterceptPdf(profile) {
   return !!profile.interceptPdf;
 }
 
+function getProfileSuspendTimeout(profile) {
+  if (!profile || profile.suspendTimeoutMinutes === undefined) return 30;
+  return profile.suspendTimeoutMinutes;
+}
+
 const MAX_URL_HISTORY = 100;
 const MAX_URL_COUNT = 10;
 const URL_DECAY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
@@ -49,6 +54,11 @@ let focusedPanelId = null;
 function setFocusedPanel(panelId) {
   if (focusedPanelId === panelId) return;
 
+  // Start suspend timer for previous web panel losing focus
+  if (focusedPanelId && activeWebPanels.has(focusedPanelId)) {
+    startSuspendTimer(focusedPanelId);
+  }
+
   // Clear previous
   if (focusedPanelId) {
     const prevEl = document.querySelector(`[data-panel-id="${focusedPanelId}"]`);
@@ -62,6 +72,12 @@ function setFocusedPanel(panelId) {
   if (panelId) {
     const el = document.querySelector(`[data-panel-id="${panelId}"]`);
     if (el) el.classList.add('panel-focused');
+
+    // Stop suspend timer for newly focused web panel; auto-resume if suspended
+    if (activeWebPanels.has(panelId)) {
+      clearSuspendTimer(panelId);
+      if (isSuspended(panelId)) resumePanel(panelId);
+    }
   }
 }
 
@@ -96,6 +112,7 @@ function migrateProfile(profile) {
   if (!profile.maxPanels) {
     profile.maxPanels = { terminal: MAX_TERMINAL_PANELS, web: MAX_WEB_PANELS, file: MAX_FILE_PANELS };
   }
+  if (profile.suspendTimeoutMinutes === undefined) profile.suspendTimeoutMinutes = 30;
 }
 
 async function init() {
@@ -304,6 +321,7 @@ function selectGroup(groupId) {
   saveState();
   renderSidebar();
   renderPanelStrip();
+  resetTimersForGroup(groupId);
 }
 
 function killGroupTerminals(group) {
@@ -317,6 +335,8 @@ function killGroupTerminals(group) {
       if (dispose) dispose();
     }
     if (p.type === 'web' && activeWebPanels.has(p.id)) {
+      clearSuspendTimer(p.id);
+      suspendedPanels.delete(p.id);
       const { cleanup } = activeWebPanels.get(p.id);
       if (cleanup) cleanup();
     }
@@ -494,6 +514,8 @@ function removePanel(panelId) {
     if (dispose) dispose();
   }
   if (activeWebPanels.has(panelId)) {
+    clearSuspendTimer(panelId);
+    suspendedPanels.delete(panelId);
     const { cleanup } = activeWebPanels.get(panelId);
     if (cleanup) cleanup();
   }
@@ -751,6 +773,10 @@ function teardownCurrentProfile() {
   groupDOMCache.forEach((el) => el.remove());
   groupDOMCache.clear();
   lruOrder.length = 0;
+
+  // Clear suspend state
+  clearAllSuspendTimers();
+  suspendedPanels.clear();
 
   // Clear active maps
   activeTerminals.clear();

--- a/renderer/core/suspend-manager.js
+++ b/renderer/core/suspend-manager.js
@@ -1,0 +1,77 @@
+// suspend-manager.js - Auto-suspend inactive web panels to save resources
+
+const suspendTimers = new Map();   // panelId -> timeoutId
+const suspendedPanels = new Map(); // panelId -> { url, title }
+
+function getSuspendTimeoutMs() {
+  const profile = getActiveProfile();
+  const minutes = profile ? (profile.suspendTimeoutMinutes ?? 30) : 30;
+  if (minutes <= 0) return Infinity;
+  return minutes * 60 * 1000;
+}
+
+function startSuspendTimer(panelId) {
+  clearSuspendTimer(panelId);
+  if (isSuspended(panelId)) return;
+  if (panelId === focusedPanelId) return;
+  const ms = getSuspendTimeoutMs();
+  if (!isFinite(ms)) return;
+  const id = setTimeout(() => {
+    suspendTimers.delete(panelId);
+    suspendPanel(panelId);
+  }, ms);
+  suspendTimers.set(panelId, id);
+}
+
+function resetSuspendTimer(panelId) {
+  if (isSuspended(panelId)) return;
+  startSuspendTimer(panelId);
+}
+
+function clearSuspendTimer(panelId) {
+  const id = suspendTimers.get(panelId);
+  if (id !== undefined) {
+    clearTimeout(id);
+    suspendTimers.delete(panelId);
+  }
+}
+
+function clearAllSuspendTimers() {
+  for (const [, id] of suspendTimers) clearTimeout(id);
+  suspendTimers.clear();
+}
+
+function suspendPanel(panelId) {
+  if (isSuspended(panelId)) return;
+  const entry = activeWebPanels.get(panelId);
+  if (!entry || !entry.suspend) return;
+  entry.suspend();
+  renderStatusBar();
+}
+
+function resumePanel(panelId) {
+  if (!isSuspended(panelId)) return;
+  const entry = activeWebPanels.get(panelId);
+  if (!entry || !entry.resume) return;
+  const saved = suspendedPanels.get(panelId);
+  suspendedPanels.delete(panelId);
+  entry.resume(saved ? saved.url : '');
+  startSuspendTimer(panelId);
+  renderStatusBar();
+}
+
+function isSuspended(panelId) {
+  return suspendedPanels.has(panelId);
+}
+
+function resetTimersForGroup(groupId) {
+  const profile = getActiveProfile();
+  if (!profile) return;
+  const group = profile.groups.find(g => g.id === groupId);
+  if (!group) return;
+  for (const panel of group.panels) {
+    if (panel.type === 'web' && !isSuspended(panel.id)) {
+      startSuspendTimer(panel.id);
+    }
+  }
+}

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -24,6 +24,7 @@
   <script src="../node_modules/@xterm/addon-web-links/lib/addon-web-links.js"></script>
   <script src="core/app.js"></script>
   <script src="core/group-cache.js"></script>
+  <script src="core/suspend-manager.js"></script>
   <script src="modals/workspace-modal.js"></script>
   <script src="modals/panel-settings-modal.js"></script>
   <script src="modals/profile-settings-modal.js"></script>

--- a/renderer/modals/profile-settings-modal.js
+++ b/renderer/modals/profile-settings-modal.js
@@ -69,6 +69,25 @@ function showProfileSettingsModal(profile) {
   pdfField.appendChild(pdfLabel);
   container.appendChild(pdfField);
 
+  // ── Auto-suspend timeout ──
+  const suspendField = document.createElement('div');
+  suspendField.className = 'modal-field';
+
+  const suspendLabel = document.createElement('label');
+  suspendLabel.className = 'modal-label';
+  suspendLabel.textContent = 'Auto-suspend web panels after (minutes, 0 = off)';
+
+  const suspendInput = document.createElement('input');
+  suspendInput.className = 'modal-input';
+  suspendInput.type = 'number';
+  suspendInput.min = '0';
+  suspendInput.max = '120';
+  suspendInput.value = getProfileSuspendTimeout(profile);
+
+  suspendField.appendChild(suspendLabel);
+  suspendField.appendChild(suspendInput);
+  container.appendChild(suspendField);
+
   const footer = document.createElement('div');
   footer.className = 'modal-footer';
 
@@ -102,6 +121,8 @@ function showProfileSettingsModal(profile) {
     }
     profile.maxPanels = newMaxPanels;
     profile.interceptPdf = pdfCheckbox.checked;
+    const suspendVal = parseInt(suspendInput.value, 10);
+    profile.suspendTimeoutMinutes = isNaN(suspendVal) ? 30 : Math.max(0, Math.min(120, suspendVal));
     saveState();
     renderStatusBar();
     dismiss();

--- a/renderer/panels/panel-strip.js
+++ b/renderer/panels/panel-strip.js
@@ -154,6 +154,23 @@ function createPanelElement(panel) {
 
   header.appendChild(typeLabel);
   header.appendChild(settingsBtn);
+
+  if (panel.type === 'web') {
+    const suspendBtn = document.createElement('button');
+    suspendBtn.className = 'panel-suspend-btn';
+    suspendBtn.textContent = '\u23F8';
+    suspendBtn.title = 'Suspend panel';
+    suspendBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      if (isSuspended(panel.id)) {
+        resumePanel(panel.id);
+      } else {
+        suspendPanel(panel.id);
+      }
+    });
+    header.appendChild(suspendBtn);
+  }
+
   header.appendChild(closeBtn);
   el.appendChild(header);
 

--- a/renderer/panels/status-bar.js
+++ b/renderer/panels/status-bar.js
@@ -25,6 +25,14 @@ function renderStatusBar() {
         `${label} ${activeCount} active \u00b7 ${count} / ${max}` +
         `</span>`;
     }
+    if (type === 'web') {
+      const suspCount = typeof suspendedPanels !== 'undefined' ? suspendedPanels.size : 0;
+      const suffix = suspCount > 0 ? ` \u00b7 ${suspCount} suspended` : '';
+      return `<span class="status-bar-item">` +
+        `<span class="status-bar-dot ${type}"></span>` +
+        `${label} ${count} / ${max}${suffix}` +
+        `</span>`;
+    }
     return `<span class="status-bar-item">` +
       `<span class="status-bar-dot ${type}"></span>` +
       `${label} ${count} / ${max}` +

--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -367,6 +367,24 @@ function renderWebPanel(panel, container) {
   const navigate = (raw) => {
     let url = raw.trim();
     if (!url) return;
+    // Auto-resume if panel is suspended and user initiates navigation
+    if (isSuspended(panel.id)) {
+      const overlay = webviewWrapper.querySelector('.suspend-overlay');
+      if (overlay) overlay.remove();
+      const panelEl = webview.closest('.panel');
+      if (panelEl) {
+        const lbl = panelEl.querySelector('.panel-type-label');
+        if (lbl) lbl.classList.remove('panel-label-suspended');
+        const suspBtn = panelEl.querySelector('.panel-suspend-btn');
+        if (suspBtn) {
+          suspBtn.textContent = '\u23F8';
+          suspBtn.title = 'Suspend panel';
+          suspBtn.classList.remove('suspended');
+        }
+      }
+      suspendedPanels.delete(panel.id);
+      startSuspendTimer(panel.id);
+    }
     hideBookmarkOverlay();
     if (navigateInFlight) {
       console.log(`[WebPanel] navigate blocked — already in flight panel=${panel.id}`);
@@ -479,6 +497,8 @@ function renderWebPanel(panel, container) {
   webview.addEventListener('did-navigate', e => {
     console.log(`[WebPanel] did-navigate panel=${panel.id} url=${e.url}`);
     navigateInFlight = false;
+    // Skip state updates when navigating to about:blank due to suspension
+    if (isSuspended(panel.id)) return;
     errorPageShownForUrl = null;
     removeErrorOverlay();
     if (!e.url.startsWith('data:')) {
@@ -506,6 +526,7 @@ function renderWebPanel(panel, container) {
   });
 
   webview.addEventListener('did-navigate-in-page', e => {
+    if (isSuspended(panel.id)) return;
     if (e.isMainFrame && !e.url.startsWith('data:')) {
       lastRealUrl = e.url;
       urlInput.value = e.url;
@@ -568,6 +589,7 @@ function renderWebPanel(panel, container) {
   // BUT keep capture alive if the search bar is currently visible/active
   webview.addEventListener('focus', () => {
     setFocusedPanel(panel.id);
+    resetSuspendTimer(panel.id);
     const entry = activePanelSearches.get(panel.id);
     if (entry && !entry.bar.hidden) {
       console.log('[WebPanel] focus event — search bar active, refocusing search input');
@@ -588,6 +610,7 @@ function renderWebPanel(panel, container) {
   });
 
   webview.addEventListener('page-title-updated', e => {
+    if (isSuspended(panel.id)) return;
     if (webview.getURL().startsWith('data:')) return;
     // Update CDP tracking with new title
     if (window.electronAPI.cdpUpdateWebview && webview._webContentsId) {
@@ -613,8 +636,87 @@ function renderWebPanel(panel, container) {
     }
   });
 
+  // ── Suspend / Resume ─────────────────────────────
+  const suspend = () => {
+    if (isSuspended(panel.id)) return;
+    const url = lastRealUrl || panel.url || '';
+    const panelEl = webview.closest('.panel');
+    const title = panelEl ? (panelEl.querySelector('.panel-type-label')?.textContent || 'Web') : 'Web';
+    suspendedPanels.set(panel.id, { url, title });
+
+    // Create suspend overlay
+    const overlay = document.createElement('div');
+    overlay.className = 'suspend-overlay';
+    const icon = document.createElement('div');
+    icon.className = 'suspend-overlay-icon';
+    icon.textContent = '\u23F8';
+    const text = document.createElement('div');
+    text.className = 'suspend-overlay-text';
+    text.textContent = 'Panel suspended to save resources';
+    const urlLabel = document.createElement('div');
+    urlLabel.className = 'suspend-overlay-url';
+    urlLabel.textContent = url;
+    const resumeBtn = document.createElement('button');
+    resumeBtn.className = 'suspend-overlay-resume';
+    resumeBtn.textContent = 'Click to resume';
+    resumeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      resumePanel(panel.id);
+    });
+    overlay.appendChild(icon);
+    overlay.appendChild(text);
+    overlay.appendChild(urlLabel);
+    overlay.appendChild(resumeBtn);
+    overlay.addEventListener('click', () => resumePanel(panel.id));
+    webviewWrapper.appendChild(overlay);
+
+    // Dim the panel header label
+    if (panelEl) {
+      const lbl = panelEl.querySelector('.panel-type-label');
+      if (lbl) lbl.classList.add('panel-label-suspended');
+      const suspBtn = panelEl.querySelector('.panel-suspend-btn');
+      if (suspBtn) {
+        suspBtn.textContent = '\u25B6';
+        suspBtn.title = 'Resume panel';
+        suspBtn.classList.add('suspended');
+      }
+    }
+
+    webview.loadURL('about:blank').catch(() => {});
+    console.log(`[WebPanel] Suspended panel=${panel.id} url=${url}`);
+  };
+
+  const resume = (url) => {
+    // Remove suspend overlay
+    const overlay = webviewWrapper.querySelector('.suspend-overlay');
+    if (overlay) overlay.remove();
+
+    // Restore panel header label
+    const panelEl = webview.closest('.panel');
+    if (panelEl) {
+      const lbl = panelEl.querySelector('.panel-type-label');
+      if (lbl) lbl.classList.remove('panel-label-suspended');
+      const suspBtn = panelEl.querySelector('.panel-suspend-btn');
+      if (suspBtn) {
+        suspBtn.textContent = '\u23F8';
+        suspBtn.title = 'Suspend panel';
+        suspBtn.classList.remove('suspended');
+      }
+    }
+
+    if (url) {
+      navigate(url);
+    }
+    console.log(`[WebPanel] Resumed panel=${panel.id} url=${url}`);
+  };
+
+  // Start inactivity timer
+  startSuspendTimer(panel.id);
+
   // Cleanup function — mirrors the pattern used by mountTerminal() in term-panel.js
   const cleanup = () => {
+    clearSuspendTimer(panel.id);
+    suspendedPanels.delete(panel.id);
     const wcId = webview._webContentsId;
     if (wcId !== undefined) {
       webviewRegistry.delete(wcId);
@@ -625,5 +727,5 @@ function renderWebPanel(panel, container) {
     destroyPanelSearch(panel.id);
     activeWebPanels.delete(panel.id);
   };
-  activeWebPanels.set(panel.id, { cleanup });
+  activeWebPanels.set(panel.id, { cleanup, suspend, resume });
 }

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -478,6 +478,76 @@ body.resizing, body.resizing * { cursor: col-resize !important; }
 
 .panel-settings-btn:hover { color: #ccc; background: #2a2a4e; }
 
+.panel-suspend-btn {
+  background: none;
+  border: none;
+  color: #556;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 1px 3px;
+  border-radius: 3px;
+  transition: color 0.12s, background 0.12s;
+}
+.panel-suspend-btn:hover { color: #ccc; background: #2a2a4e; }
+.panel-suspend-btn.suspended { color: #f38ba8; }
+
+.panel-label-suspended { opacity: 0.5; }
+
+/* ── Suspend overlay ─────────────────────────────── */
+
+.suspend-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 8;
+  background: #1e1e2e;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  cursor: pointer;
+}
+
+.suspend-overlay-icon {
+  font-size: 3rem;
+  color: #533483;
+  opacity: 0.7;
+}
+
+.suspend-overlay-text {
+  font-size: 14px;
+  color: #889;
+}
+
+.suspend-overlay-url {
+  font-size: 11px;
+  color: #556;
+  max-width: 80%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+}
+
+.suspend-overlay-resume {
+  margin-top: 8px;
+  padding: 8px 20px;
+  background: #3d2b6e;
+  border: 1px solid #533483;
+  color: #e0d0ff;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.suspend-overlay-resume:hover {
+  background: #4d3b8e;
+  border-color: #7355a8;
+  color: #fff;
+}
+
 .panel.dragging {
   opacity: 0.5;
   z-index: 100;


### PR DESCRIPTION
Closes #120

Web panels that remain inactive (unfocused) for a configurable period are automatically suspended by navigating to about:blank, stopping all JS execution, network requests, and timers. A visual overlay indicates the suspended state with a click-to-resume button.

- Add suspend-manager.js for per-panel inactivity timers
- Add suspend/resume functions in web-panel.js with did-navigate guards
- Integrate with focus tracking, group switching, and cleanup in app.js
- Add configurable timeout in profile settings (default 30 min, 0 = off)
- Add suspend toggle button in web panel headers
- Show suspended panel count in status bar