### PR TITLE
feat: Handle TLS certificate errors in web panels with per-panel and …

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,6 +61,14 @@ let browserInterceptPort = 0;
 const browserInterceptToken = crypto.randomBytes(16).toString('hex');
 let browserHelperDir = null;
 
+// TLS certificate error handling for web panels.
+// Per-panel host exemptions: webContentsId -> Set<host>. Cleared when the
+// webContents is destroyed (e.g. panel closed) or on app restart.
+const tlsExemptions = new Map();
+// Profile-level kill-switch: when true, all cert errors on webview contents
+// using the persist:webpanels session are silently allowed.
+let ignoreAllTlsErrors = false;
+
 function execFilePromise(command, args, options) {
   return new Promise((resolve) => {
     execFile(command, args, options, (error, stdout, stderr) => {
@@ -606,6 +614,32 @@ ipcMain.handle('debug:listPanels', () => {
     panels.push({ webContentsId: wcId, panelId: info.panelId, url: info.url, title: info.title });
   }
   return panels;
+});
+
+// TLS: add a per-panel host exemption, then reload so the now-allowed cert
+// passes the certificate-error handler above.
+ipcMain.handle('tls:allow-host', (_, { webContentsId, host }) => {
+  if (!webContentsId || !host) return { ok: false };
+  let set = tlsExemptions.get(webContentsId);
+  if (!set) {
+    set = new Set();
+    tlsExemptions.set(webContentsId, set);
+  }
+  set.add(host);
+  debugLog('[TLS] allowed host for wcId:', webContentsId, 'host:', host);
+  const wc = webContents.fromId(webContentsId);
+  if (wc && !wc.isDestroyed()) {
+    wc.reload();
+  }
+  return { ok: true };
+});
+
+// TLS: toggle the profile-level kill-switch. When true, every cert error on
+// persist:webpanels webviews is silently allowed.
+ipcMain.handle('tls:set-ignore-all', (_, { enabled }) => {
+  ignoreAllTlsErrors = !!enabled;
+  debugLog('[TLS] ignoreAllTlsErrors =', ignoreAllTlsErrors);
+  return { ok: true };
 });
 
 function setupBrowserHelperScripts() {
@@ -1236,11 +1270,71 @@ app.whenReady().then(async () => {
   });
   debugLog('[WebPanels] Registered onHeadersReceived to strip anti-framing headers');
 
+  // TLS certificate errors: only handle webview contents on persist:webpanels.
+  // Default: block (callback(false)) so did-fail-load surfaces in the renderer
+  // and the warning page is shown. Allow when the profile-level toggle is on
+  // or the user has explicitly exempted this host for this panel.
+  app.on('certificate-error', (event, wc, url, error, certificate, callback) => {
+    if (!wc || wc.isDestroyed() || wc.getType() !== 'webview') {
+      return callback(false);
+    }
+    let partition = null;
+    try { partition = wc.session && wc.session.getStoragePath ? wc.session.storagePath : null; } catch (e) {}
+    // Robust check: only apply to our webpanel session.
+    const isWebPanel = wc.session === session.fromPartition('persist:webpanels');
+    if (!isWebPanel) return callback(false);
+
+    let host = '';
+    try { host = new URL(url).host; } catch (e) {}
+
+    if (ignoreAllTlsErrors) {
+      event.preventDefault();
+      callback(true);
+      return;
+    }
+
+    const allowed = tlsExemptions.get(wc.id);
+    if (allowed && host && allowed.has(host)) {
+      event.preventDefault();
+      callback(true);
+      return;
+    }
+
+    debugLog('[TLS] cert-error wcId:', wc.id, 'host:', host, 'error:', error, 'url:', url);
+
+    // Send cert details to the renderer so the warning page can display
+    // issuer/validity. Use the host webContents (main window).
+    const host_wc = wc.hostWebContents;
+    if (host_wc && !host_wc.isDestroyed()) {
+      host_wc.send('tls:error-details', {
+        webContentsId: wc.id,
+        url,
+        host,
+        error,
+        certificate: certificate ? {
+          subjectName: certificate.subjectName || (certificate.subject && certificate.subject.commonName) || '',
+          issuerName: certificate.issuerName || (certificate.issuer && certificate.issuer.commonName) || '',
+          validStart: certificate.validStart || 0,
+          validExpiry: certificate.validExpiry || 0,
+          fingerprint: certificate.fingerprint || '',
+          serialNumber: certificate.serialNumber || '',
+        } : null,
+      });
+    }
+
+    callback(false);
+  });
+
   // Log webview render process crashes
   app.on('web-contents-created', (_, contents) => {
     debugLog('[web-contents-created] type:', contents.getType());
     contents.on('render-process-gone', (event, details) => {
       debugLog('[render-process-gone] reason:', details.reason, 'exitCode:', details.exitCode);
+    });
+    contents.once('destroyed', () => {
+      if (tlsExemptions.delete(contents.id)) {
+        debugLog('[TLS] cleared exemptions for destroyed wcId:', contents.id);
+      }
     });
     contents.on('did-fail-load', (event, errorCode, errorDescription, validatedURL) => {
       debugLog('[did-fail-load] code:', errorCode, 'desc:', errorDescription, 'url:', validatedURL);

--- a/preload.js
+++ b/preload.js
@@ -128,4 +128,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on(channel, listener);
     return () => ipcRenderer.removeListener(channel, listener);
   },
+
+  // TLS certificate error handling for web panels
+  tlsAllowHost: (webContentsId, host) =>
+    ipcRenderer.invoke('tls:allow-host', { webContentsId, host }),
+  tlsSetIgnoreAll: (enabled) =>
+    ipcRenderer.invoke('tls:set-ignore-all', { enabled }),
+  onTlsErrorDetails: (callback) => {
+    const listener = (_, data) => callback(data);
+    ipcRenderer.on('tls:error-details', listener);
+    return () => ipcRenderer.removeListener('tls:error-details', listener);
+  },
 });

--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -26,6 +26,17 @@ function getProfileInterceptPdf(profile) {
   return !!profile.interceptPdf;
 }
 
+function getProfileIgnoreTlsErrors(profile) {
+  if (!profile || profile.ignoreTlsErrors === undefined) return false;
+  return !!profile.ignoreTlsErrors;
+}
+
+function syncTlsIgnoreToMain() {
+  if (window.electronAPI && window.electronAPI.tlsSetIgnoreAll) {
+    window.electronAPI.tlsSetIgnoreAll(getProfileIgnoreTlsErrors(getActiveProfile()));
+  }
+}
+
 const MAX_URL_HISTORY = 100;
 const MAX_URL_COUNT = 10;
 const URL_DECAY_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
@@ -157,6 +168,7 @@ async function init() {
   renderSidebar();
   document.getElementById('sidebar').style.width = state.sidebarWidth + 'px';
   renderPanelStrip();
+  syncTlsIgnoreToMain();
 
   let windowResizeTimer = null;
   window.addEventListener('resize', () => {
@@ -805,6 +817,7 @@ function addProfile(name) {
   saveState();
   renderSidebar();
   renderPanelStrip();
+  syncTlsIgnoreToMain();
 }
 
 function switchProfile(profileId) {
@@ -816,6 +829,7 @@ function switchProfile(profileId) {
   saveState();
   renderSidebar();
   renderPanelStrip();
+  syncTlsIgnoreToMain();
 }
 
 function renameProfile(profileId, newName) {

--- a/renderer/modals/profile-settings-modal.js
+++ b/renderer/modals/profile-settings-modal.js
@@ -70,6 +70,29 @@ function showProfileSettingsModal(profile) {
   pdfField.appendChild(pdfLabel);
   container.appendChild(pdfField);
 
+  // ── Ignore TLS errors toggle ──
+  const tlsField = document.createElement('div');
+  tlsField.className = 'modal-field';
+  tlsField.style.flexDirection = 'row';
+  tlsField.style.alignItems = 'center';
+  tlsField.style.gap = '8px';
+
+  const tlsCheckbox = document.createElement('input');
+  tlsCheckbox.type = 'checkbox';
+  tlsCheckbox.id = 'ignore-tls-checkbox';
+  tlsCheckbox.checked = getProfileIgnoreTlsErrors(profile);
+
+  const tlsLabel = document.createElement('label');
+  tlsLabel.className = 'modal-label';
+  tlsLabel.setAttribute('for', 'ignore-tls-checkbox');
+  tlsLabel.textContent = 'Ignore all TLS certificate errors';
+  tlsLabel.title = 'Insecure — allows any invalid certificate on web panels';
+  tlsLabel.style.marginBottom = '0';
+
+  tlsField.appendChild(tlsCheckbox);
+  tlsField.appendChild(tlsLabel);
+  container.appendChild(tlsField);
+
   const footer = document.createElement('div');
   footer.className = 'modal-footer';
 
@@ -103,8 +126,12 @@ function showProfileSettingsModal(profile) {
     }
     profile.maxPanels = newMaxPanels;
     profile.interceptPdf = pdfCheckbox.checked;
+    profile.ignoreTlsErrors = tlsCheckbox.checked;
     saveState();
     renderStatusBar();
+    if (window.electronAPI && window.electronAPI.tlsSetIgnoreAll) {
+      window.electronAPI.tlsSetIgnoreAll(!!profile.ignoreTlsErrors);
+    }
     dismiss();
   }
 

--- a/renderer/panels/web-panel.js
+++ b/renderer/panels/web-panel.js
@@ -3,6 +3,45 @@
 // Registry: webContentsId -> { panelId, refresh(), showSearch() }
 const webviewRegistry = new Map();
 
+// Latest TLS cert error details pushed from main, keyed by webContentsId.
+// The certificate-error event fires before did-fail-load, so the warning page
+// renderer can look up details here. One entry per wc — replaced on each error.
+const tlsErrorDetails = new Map();
+if (window.electronAPI && window.electronAPI.onTlsErrorDetails) {
+  window.electronAPI.onTlsErrorDetails((data) => {
+    if (data && data.webContentsId) {
+      tlsErrorDetails.set(data.webContentsId, data);
+    }
+  });
+}
+
+// Chromium net error codes for certificate failures (handled in warning page).
+// See net/base/net_error_list.h — codes land in did-fail-load's errorCode.
+function isCertErrorCode(code) {
+  return code <= -200 && code >= -299;
+}
+function describeCertError(code, description) {
+  const map = {
+    [-200]: 'Certificate is invalid',
+    [-201]: 'Certificate authority is not trusted',
+    [-202]: 'Certificate does not match the hostname',
+    [-203]: 'Certificate has expired or is not yet valid',
+    [-204]: 'Certificate contains errors',
+    [-205]: 'No revocation mechanism available',
+    [-206]: 'Unable to check certificate revocation',
+    [-207]: 'Certificate revoked',
+    [-208]: 'Invalid certificate',
+    [-209]: 'Certificate is weakly signed',
+    [-210]: 'Certificate uses a non-unique name',
+    [-211]: 'Certificate chain uses a weak key',
+    [-212]: 'Name-constraint violation in certificate',
+    [-213]: 'Certificate validity period is too long',
+    [-215]: 'Certificate Transparency requirements not met',
+    [-216]: 'Certificate known to be compromised',
+  };
+  return map[code] || description || 'Certificate error';
+}
+
 // IPC listeners for Cmd+R and Cmd+F from main process before-input-event
 if (window.electronAPI.onWebviewRefresh) {
   window.electronAPI.onWebviewRefresh(({ webContentsId }) => {
@@ -339,6 +378,84 @@ function renderWebPanel(panel, container) {
   function removeErrorOverlay() {
     const overlay = webviewWrapper.querySelector('.webview-error-overlay');
     if (overlay) overlay.remove();
+    const tlsOverlay = webviewWrapper.querySelector('.webview-tls-overlay');
+    if (tlsOverlay) tlsOverlay.remove();
+  }
+
+  // TLS warning page. Rendered as a DOM overlay (not a data: URL) so the
+  // "Continue anyway" button can call IPC from the main renderer context.
+  function showTlsWarningPage(url, errorDescription, errorCode) {
+    loadingBar.classList.remove('active');
+    errorPageShownForUrl = url;
+
+    let host = '';
+    try { host = new URL(url).host; } catch (e) {}
+    const wcId = webview._webContentsId;
+    const details = wcId ? tlsErrorDetails.get(wcId) : null;
+    const cert = details && details.certificate ? details.certificate : null;
+    const errorTitle = describeCertError(errorCode, errorDescription);
+
+    const fmtDate = (ts) => {
+      if (!ts) return '—';
+      try { return new Date(ts * 1000).toUTCString(); } catch (e) { return String(ts); }
+    };
+    const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, c => (
+      { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
+
+    let overlay = webviewWrapper.querySelector('.webview-tls-overlay');
+    if (overlay) overlay.remove();
+    overlay = document.createElement('div');
+    overlay.className = 'webview-tls-overlay';
+    overlay.style.cssText = 'position:absolute;inset:0;z-index:10;display:flex;align-items:center;justify-content:center;background:#1e1e2e;color:#cdd6f4;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;overflow:auto;';
+
+    const certRows = cert ? `
+      <div style="margin-top:1rem;border-top:1px solid #45475a;padding-top:1rem;font-size:0.9rem;color:#a6adc8;text-align:left;">
+        <div><span style="color:#bac2de;">Subject:</span> ${esc(cert.subjectName) || '—'}</div>
+        <div><span style="color:#bac2de;">Issuer:</span> ${esc(cert.issuerName) || '—'}</div>
+        <div><span style="color:#bac2de;">Valid from:</span> ${esc(fmtDate(cert.validStart))}</div>
+        <div><span style="color:#bac2de;">Valid until:</span> ${esc(fmtDate(cert.validExpiry))}</div>
+        ${cert.fingerprint ? `<div style="word-break:break-all;"><span style="color:#bac2de;">Fingerprint:</span> ${esc(cert.fingerprint)}</div>` : ''}
+      </div>` : '<div style="margin-top:0.75rem;color:#6c7086;font-size:0.85rem;">Certificate details unavailable.</div>';
+
+    overlay.innerHTML = `
+      <div style="max-width:560px;padding:2rem;text-align:center;">
+        <div style="font-size:3rem;margin-bottom:0.5rem;">\u26a0</div>
+        <h2 style="margin:0 0 0.25rem;color:#f38ba8;">Your connection is not private</h2>
+        <p style="color:#a6adc8;margin:0 0 0.5rem;word-break:break-all;">${esc(url)}</p>
+        <p style="color:#f9e2af;margin:0.5rem 0 0;"><strong>${esc(errorTitle)}</strong></p>
+        <p style="color:#6c7086;font-size:0.85rem;margin:0.25rem 0 0;">${esc(errorDescription || '')} (${errorCode})</p>
+        ${certRows}
+        <div style="margin-top:1.5rem;display:flex;gap:0.75rem;justify-content:center;">
+          <button class="tls-back-btn" style="padding:0.5rem 1.25rem;border:1px solid #45475a;border-radius:6px;background:transparent;color:#cdd6f4;font-size:0.95rem;cursor:pointer;">Go back</button>
+          <button class="tls-continue-btn" style="padding:0.5rem 1.25rem;border:none;border-radius:6px;background:#f38ba8;color:#1e1e2e;font-size:0.95rem;font-weight:600;cursor:pointer;">Continue anyway</button>
+        </div>
+        <p style="color:#6c7086;font-size:0.8rem;margin-top:1rem;">Exemption applies to this panel only until it is closed.</p>
+      </div>`;
+
+    webviewWrapper.appendChild(overlay);
+
+    overlay.querySelector('.tls-back-btn').addEventListener('click', () => {
+      overlay.remove();
+      if (webview.canGoBack()) {
+        webview.goBack();
+      } else {
+        webview.src = 'about:blank';
+      }
+    });
+    overlay.querySelector('.tls-continue-btn').addEventListener('click', async () => {
+      if (!wcId || !host) {
+        overlay.remove();
+        return;
+      }
+      try {
+        await window.electronAPI.tlsAllowHost(wcId, host);
+      } catch (e) {
+        console.log(`[WebPanel] tlsAllowHost failed panel=${panel.id} host=${host} err=${e.message}`);
+      }
+      overlay.remove();
+      errorPageShownForUrl = null;
+    });
   }
 
   function showErrorPage(url, errorDescription, errorCode) {
@@ -481,6 +598,8 @@ function renderWebPanel(panel, container) {
     navigateInFlight = false;
     errorPageShownForUrl = null;
     removeErrorOverlay();
+    const tlsOverlay = webviewWrapper.querySelector('.webview-tls-overlay');
+    if (tlsOverlay) tlsOverlay.remove();
     if (!e.url.startsWith('data:')) {
       lastRealUrl = e.url;
       crashRetryCount = 0;
@@ -513,7 +632,12 @@ function renderWebPanel(panel, container) {
   webview.addEventListener('did-fail-load', e => {
     console.log(`[WebPanel] did-fail-load panel=${panel.id} error=${e.errorDescription} code=${e.errorCode} url=${e.validatedURL}`);
     if (e.errorCode === 0 || e.errorCode === -3) return; // ignore aborted loads
-    showErrorPage(e.validatedURL || lastRealUrl || '', e.errorDescription, e.errorCode);
+    const failUrl = e.validatedURL || lastRealUrl || '';
+    if (isCertErrorCode(e.errorCode)) {
+      showTlsWarningPage(failUrl, e.errorDescription, e.errorCode);
+      return;
+    }
+    showErrorPage(failUrl, e.errorDescription, e.errorCode);
   });
 
   // Handle errors dispatched from navigateWebPanel in app.js


### PR DESCRIPTION
…profile-level overrides

Certificate failures now route to a dedicated warning page that shows issuer, validity window, and the error type, with a "Continue anyway" button that grants a per-panel + per-host exemption. A new profile setting ("Ignore all TLS certificate errors") short-circuits the check entirely for webviews on the persist:webpanels session.

Closes #122