### PR TITLE
feat: Add file panel zoom controls

### DIFF
--- a/renderer/core/app.js
+++ b/renderer/core/app.js
@@ -36,6 +36,11 @@ function getProfileDefaultTermFontSize(profile) {
   return profile.defaultTermFontSize;
 }
 
+function getProfileDefaultFileFontSize(profile) {
+  if (!profile || profile.defaultFileFontSize === undefined) return 13;
+  return profile.defaultFileFontSize;
+}
+
 function syncTlsIgnoreToMain() {
   if (window.electronAPI && window.electronAPI.tlsSetIgnoreAll) {
     window.electronAPI.tlsSetIgnoreAll(getProfileIgnoreTlsErrors(getActiveProfile()));
@@ -117,6 +122,9 @@ function migrateProfile(profile) {
   }
   if (profile.defaultTermFontSize === undefined) {
     profile.defaultTermFontSize = 13;
+  }
+  if (profile.defaultFileFontSize === undefined) {
+    profile.defaultFileFontSize = 13;
   }
 }
 
@@ -911,7 +919,7 @@ document.addEventListener('keydown', e => {
   }
 });
 
-// ── Global Cmd+= / Cmd+- / Cmd+0 for terminal zoom ──
+// ── Global Cmd+= / Cmd+- / Cmd+0 for terminal & file panel zoom ──
 document.addEventListener('keydown', e => {
   if (!(e.metaKey || e.ctrlKey)) return;
   const isZoomIn = (e.key === '=' || e.key === '+');
@@ -922,14 +930,22 @@ document.addEventListener('keydown', e => {
   const group = getActiveGroup();
   if (!group) return;
   const panel = group.panels.find(p => p.id === focusedPanelId);
-  if (!panel || panel.type !== 'terminal') return;
-  e.preventDefault();
+  if (!panel) return;
   const panelEl = document.querySelector(`[data-panel-id="${focusedPanelId}"]`);
   if (!panelEl) return;
-  const termContainer = panelEl.querySelector('.term-container');
-  if (!termContainer) return;
-  const evtName = isZoomIn ? 'term-zoom-in' : isZoomOut ? 'term-zoom-out' : 'term-zoom-reset';
-  termContainer.dispatchEvent(new CustomEvent(evtName));
+  if (panel.type === 'terminal') {
+    const termContainer = panelEl.querySelector('.term-container');
+    if (!termContainer) return;
+    e.preventDefault();
+    const evtName = isZoomIn ? 'term-zoom-in' : isZoomOut ? 'term-zoom-out' : 'term-zoom-reset';
+    termContainer.dispatchEvent(new CustomEvent(evtName));
+  } else if (panel.type === 'file') {
+    const editorArea = panelEl.querySelector('.file-editor-area');
+    if (!editorArea) return;
+    e.preventDefault();
+    const evtName = isZoomIn ? 'file-zoom-in' : isZoomOut ? 'file-zoom-out' : 'file-zoom-reset';
+    editorArea.dispatchEvent(new CustomEvent(evtName));
+  }
 });
 
 document.addEventListener('DOMContentLoaded', init);

--- a/renderer/modals/profile-settings-modal.js
+++ b/renderer/modals/profile-settings-modal.js
@@ -112,6 +112,25 @@ function showProfileSettingsModal(profile) {
   fontSizeField.appendChild(fontSizeInput);
   container.appendChild(fontSizeField);
 
+  // ── Default file panel font size ──
+  const fileFontSizeField = document.createElement('div');
+  fileFontSizeField.className = 'modal-field';
+
+  const fileFontSizeLbl = document.createElement('label');
+  fileFontSizeLbl.className = 'modal-label';
+  fileFontSizeLbl.textContent = 'Default File Font Size (px)';
+
+  const fileFontSizeInput = document.createElement('input');
+  fileFontSizeInput.className = 'modal-input';
+  fileFontSizeInput.type = 'number';
+  fileFontSizeInput.min = '8';
+  fileFontSizeInput.max = '32';
+  fileFontSizeInput.value = getProfileDefaultFileFontSize(profile);
+
+  fileFontSizeField.appendChild(fileFontSizeLbl);
+  fileFontSizeField.appendChild(fileFontSizeInput);
+  container.appendChild(fileFontSizeField);
+
   const footer = document.createElement('div');
   footer.className = 'modal-footer';
 
@@ -148,6 +167,8 @@ function showProfileSettingsModal(profile) {
     profile.ignoreTlsErrors = tlsCheckbox.checked;
     const fsVal = parseInt(fontSizeInput.value, 10);
     profile.defaultTermFontSize = (!isNaN(fsVal) && fsVal >= 8 && fsVal <= 32) ? fsVal : 13;
+    const fileFsVal = parseInt(fileFontSizeInput.value, 10);
+    profile.defaultFileFontSize = (!isNaN(fileFsVal) && fileFsVal >= 8 && fileFsVal <= 32) ? fileFsVal : 13;
     saveState();
     renderStatusBar();
     if (window.electronAPI && window.electronAPI.tlsSetIgnoreAll) {

--- a/renderer/panels/file-panel.js
+++ b/renderer/panels/file-panel.js
@@ -1,5 +1,17 @@
 // file-panel.js - File explorer + Monaco editor panel
 
+const FILE_FONT_SIZES = [10, 11, 12, 13, 14, 16, 18, 20, 24, 28, 32];
+
+function findFileFontSizeIndex(size) {
+  let closest = 0;
+  let minDiff = Math.abs(FILE_FONT_SIZES[0] - size);
+  for (let i = 1; i < FILE_FONT_SIZES.length; i++) {
+    const diff = Math.abs(FILE_FONT_SIZES[i] - size);
+    if (diff < minDiff) { minDiff = diff; closest = i; }
+  }
+  return closest;
+}
+
 let monacoLoaded = false;
 let monacoLoadPromise = null;
 
@@ -157,8 +169,49 @@ function renderFilePanel(panel, container) {
   const editorArea = document.createElement('div');
   editorArea.className = 'file-editor-area';
 
+  const profile = getActiveProfile();
+  const defaultFontSize = getProfileDefaultFileFontSize(profile);
+  const initialFontSize = panel.fontSize !== undefined ? panel.fontSize : defaultFontSize;
+  let currentFontIndex = findFileFontSizeIndex(initialFontSize);
+
   const toolbar = document.createElement('div');
   toolbar.className = 'editor-toolbar';
+
+  const zoomOutBtn = document.createElement('button');
+  zoomOutBtn.className = 'nav-btn';
+  zoomOutBtn.textContent = '−';
+  zoomOutBtn.title = 'Decrease font size';
+
+  const zoomLabel = document.createElement('span');
+  zoomLabel.className = 'editor-zoom-label';
+  zoomLabel.title = 'Double-click to reset to 13px';
+  zoomLabel.style.cursor = 'pointer';
+
+  const zoomInBtn = document.createElement('button');
+  zoomInBtn.className = 'nav-btn';
+  zoomInBtn.textContent = '+';
+  zoomInBtn.title = 'Increase font size';
+
+  function updateZoomUI() {
+    zoomLabel.textContent = FILE_FONT_SIZES[currentFontIndex] + 'px';
+    zoomOutBtn.disabled = currentFontIndex <= 0;
+    zoomInBtn.disabled = currentFontIndex >= FILE_FONT_SIZES.length - 1;
+  }
+  updateZoomUI();
+
+  function applyZoom(newIndex) {
+    currentFontIndex = Math.max(0, Math.min(FILE_FONT_SIZES.length - 1, newIndex));
+    const fontSize = FILE_FONT_SIZES[currentFontIndex];
+    updateZoomUI();
+    if (currentEditor) {
+      currentEditor.updateOptions({ fontSize });
+    }
+    updatePanelFontSize(panel.id, fontSize);
+  }
+
+  zoomInBtn.addEventListener('click', () => applyZoom(currentFontIndex + 1));
+  zoomOutBtn.addEventListener('click', () => applyZoom(currentFontIndex - 1));
+  zoomLabel.addEventListener('dblclick', () => applyZoom(findFileFontSizeIndex(13)));
 
   const saveBtn = document.createElement('button');
   saveBtn.className = 'editor-save-btn';
@@ -170,9 +223,16 @@ function renderFilePanel(panel, container) {
   lspBtn.textContent = 'LSP';
   lspBtn.title = 'Language Server Settings';
 
+  toolbar.appendChild(zoomOutBtn);
+  toolbar.appendChild(zoomLabel);
+  toolbar.appendChild(zoomInBtn);
   toolbar.appendChild(saveBtn);
   toolbar.appendChild(lspBtn);
   editorArea.appendChild(toolbar);
+
+  editorArea.addEventListener('file-zoom-in', () => applyZoom(currentFontIndex + 1));
+  editorArea.addEventListener('file-zoom-out', () => applyZoom(currentFontIndex - 1));
+  editorArea.addEventListener('file-zoom-reset', () => applyZoom(findFileFontSizeIndex(13)));
 
   const tabBar = document.createElement('div');
   tabBar.className = 'editor-tab-bar';
@@ -455,7 +515,7 @@ function renderFilePanel(panel, container) {
         theme: 'vs-dark',
         automaticLayout: false,
         minimap: { enabled: false },
-        fontSize: 13,
+        fontSize: FILE_FONT_SIZES[currentFontIndex],
         fontFamily: 'Menlo, Monaco, "Courier New", monospace',
         scrollBeyondLastLine: false,
         wordWrap: 'on',

--- a/renderer/styles.css
+++ b/renderer/styles.css
@@ -1026,7 +1026,18 @@ webview {
   border-bottom: 1px solid #2a2a3e;
   gap: 6px;
   flex-shrink: 0;
-  justify-content: flex-end;
+}
+
+.editor-zoom-label {
+  font-size: 11px;
+  color: #889;
+  min-width: 36px;
+  text-align: center;
+  user-select: none;
+}
+
+.editor-toolbar .editor-save-btn {
+  margin-left: auto;
 }
 
 .editor-save-btn,


### PR DESCRIPTION
Mirror the terminal panel zoom pattern for the Monaco-backed file panel:
- +/- buttons and a size label in the editor toolbar, double-click to reset
- Cmd/Ctrl +=/-/0 keyboard shortcuts when a file panel is focused
- Per-panel font size persists via existing updatePanelFontSize
- New profile.defaultFileFontSize setting, editable in Profile Settings