### PR TITLE
feat: Add Linux build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "electron .",
     "rebuild-pty": "node node_modules/@electron/rebuild/lib/cli.js -f -w node-pty",
     "build": "electron-builder --mac",
-    "build:dir": "electron-builder --mac --dir"
+    "build:dir": "electron-builder --mac --dir",
+    "build:linux": "electron-builder --linux"
   },
   "build": {
     "appId": "com.worklayer.app",
@@ -23,6 +24,15 @@
         }
       ],
       "identity": null
+    },
+    "linux": {
+      "category": "Development",
+      "target": [
+        { "target": "AppImage", "arch": ["x64", "arm64"] },
+        { "target": "deb",      "arch": ["x64", "arm64"] },
+        { "target": "rpm",      "arch": ["x64", "arm64"] },
+        { "target": "tar.gz",   "arch": ["x64", "arm64"] }
+      ]
     },
     "files": [
       "main.js",


### PR DESCRIPTION
Adds electron-builder targets for AppImage, deb, rpm, and tar.gz (x64 and arm64) plus a build:linux script. No runtime code changes; existing platform guards in main.js already handle Linux.

Closes #129